### PR TITLE
Add task to make npmInstall use 'ci' instead of 'install'

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/NodePlugin.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/NodePlugin.groovy
@@ -1,5 +1,6 @@
 package com.moowork.gradle.node
 
+import com.moowork.gradle.node.npm.NpmCiTask
 import com.moowork.gradle.node.npm.NpmInstallTask
 import com.moowork.gradle.node.npm.NpmSetupTask
 import com.moowork.gradle.node.npm.NpmTask
@@ -54,6 +55,7 @@ class NodePlugin
     private void addTasks()
     {
         this.project.tasks.create( NpmInstallTask.NAME, NpmInstallTask )
+        this.project.tasks.create( NpmCiTask.NAME, NpmCiTask )
         this.project.tasks.create( YarnInstallTask.NAME, YarnInstallTask )
         this.setupTask = this.project.tasks.create( SetupTask.NAME, SetupTask )
         this.npmSetupTask = this.project.tasks.create( NpmSetupTask.NAME, NpmSetupTask )

--- a/src/main/groovy/com/moowork/gradle/node/npm/NpmCiTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/npm/NpmCiTask.groovy
@@ -1,0 +1,27 @@
+package com.moowork.gradle.node.npm
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+
+/**
+ * Task for making npmInstall use npm ci instead of npm install.*/
+class NpmCiTask
+    extends DefaultTask
+{
+    public final static String NAME = 'npmCi'
+
+    NpmCiTask()
+    {
+        this.group = 'Node'
+        this.description = 'Make npm installation use the "ci" command'
+        this.outputs.upToDateWhen { false }
+    }
+
+    @TaskAction
+    void configure() {
+        project.tasks.withType(NpmInstallTask.class).each {
+            it.npmCommand = ['ci']
+            project.logger.debug("Reconfiguring: ${it.name}" )
+        }
+    }
+}

--- a/src/main/groovy/com/moowork/gradle/node/npm/NpmInstallTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/npm/NpmInstallTask.groovy
@@ -13,6 +13,7 @@ class NpmInstallTask
         this.description = 'Install node packages from package.json.'
         setNpmCommand( 'install' )
         dependsOn( [NpmSetupTask.NAME] )
+        mustRunAfter( [NpmCiTask.NAME] )
 
         this.project.afterEvaluate {
             getInputs().file( new File( (File) this.project.node.nodeModulesDir, 'package.json' ) )


### PR DESCRIPTION
This adds task `npmCi` which changes NpmInstall tasks to use `ci` instead of `install`