### PR TITLE
make use of patternLayout instead of layout 'pattern' on gradle 5.0 and later to ensure compatibilty with gradle 6.0

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -178,9 +178,16 @@ class SetupTask
         def distUrl = this.config.distBaseUrl
         this.repo = this.project.repositories.ivy {
             url distUrl
-            layout 'pattern', {
-                artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
-                ivy 'v[revision]/ivy.xml'
+            if (BackwardsCompat.usePatternLayout()) {
+                patternLayout {
+                    artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
+                    ivy 'v[revision]/ivy.xml'
+                }
+            } else {
+                layout 'pattern', {
+                    artifact 'v[revision]/[artifact](-v[revision]-[classifier]).[ext]'
+                    ivy 'v[revision]/ivy.xml'
+                }
             }
             if (BackwardsCompat.useMetadataSourcesRepository()) {
                 metadataSources {

--- a/src/main/groovy/com/moowork/gradle/node/util/BackwardsCompat.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/util/BackwardsCompat.groovy
@@ -3,9 +3,14 @@ package com.moowork.gradle.node.util;
 import org.gradle.util.GradleVersion;
 
 class BackwardsCompat {
-     private static boolean IS_GRADLE_MIN_45 = GradleVersion.current().compareTo(GradleVersion.version("4.5"))>=0;
+    private static boolean IS_GRADLE_MIN_45 = GradleVersion.current().compareTo(GradleVersion.version("4.5"))>=0;
+    private static boolean IS_GRADLE_MIN_50 = GradleVersion.current().compareTo(GradleVersion.version("5.0"))>=0;
 
     static boolean useMetadataSourcesRepository() {
         return IS_GRADLE_MIN_45
+    }
+
+    static boolean usePatternLayout() {
+        return IS_GRADLE_MIN_50
     }
 }


### PR DESCRIPTION
make use of patternLayout instead of layout 'pattern' on gradle 5.0 and later to ensure compatibilty with gradle 6.0

fixes node-gradle/gradle-node-plugin#2 respectively
srs/gradle-node-plugin#316

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>