### PR TITLE
Set the node group to the npx task

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/npm/NpxTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/npm/NpxTask.groovy
@@ -1,5 +1,6 @@
 package com.moowork.gradle.node.npm
 
+import com.moowork.gradle.node.NodePlugin
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -20,6 +21,7 @@ class NpxTask
 
     NpxTask()
     {
+        this.group = NodePlugin.NODE_GROUP
         this.runner = new NpxExecRunner( this.project )
         dependsOn( NpmSetupTask.NAME )
 


### PR DESCRIPTION
I saw that the commit 30c13c29cca3c9820b2aa501aa3e96600b5d11cb introduces a constant for the name of the task group. This make me think that I did not set the group in the NpxTask. Here it is!