### PR TITLE
Print the output of the integration test builds so that we can access it in the test reports

### DIFF
--- a/src/test/groovy/com/moowork/gradle/AbstractIntegTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/AbstractIntegTest.groovy
@@ -29,7 +29,8 @@ abstract class AbstractIntegTest
         return GradleRunner.create().
             withProjectDir( this.projectDir ).
             withArguments( args ).
-            withPluginClasspath();
+            withPluginClasspath().
+            forwardOutput();
     }
 
     protected final BuildResult build( final String... args )


### PR DESCRIPTION
I added this change each time I had to debug an integration test when working on the NpxTask pull request. I did not commit it but I think that would make sense to do it. I don't think that has any unwanted side-effect.

What do you think about that?