### PR TITLE
Run integration tests with multiple Gradle versions

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/src/test/groovy/com/moowork/gradle/AbstractIntegTest.groovy
+++ b/src/test/groovy/com/moowork/gradle/AbstractIntegTest.groovy
@@ -4,22 +4,27 @@ import org.apache.commons.io.FileUtils
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
 
+@RunWithMultipleGradleVersions
 abstract class AbstractIntegTest
     extends Specification
 {
     @Rule
     final TemporaryFolder temporaryFolder = new TemporaryFolder();
 
-    def File projectDir;
+    File projectDir
 
-    def File buildFile;
+    File buildFile
 
-    def setup()
+    GradleVersion gradleVersion = null
+
+    def setup(GradleVersion gradleVersion)
     {
+        this.gradleVersion = gradleVersion
         this.projectDir = this.temporaryFolder.root.toPath().toRealPath().toFile()
         this.buildFile = createFile( 'build.gradle' )
     }
@@ -30,7 +35,8 @@ abstract class AbstractIntegTest
             withProjectDir( this.projectDir ).
             withArguments( args ).
             withPluginClasspath().
-            forwardOutput();
+            forwardOutput().
+            withGradleVersion(gradleVersion.version);
     }
 
     protected final BuildResult build( final String... args )

--- a/src/test/groovy/com/moowork/gradle/RunWithMultipleGradleVersions.groovy
+++ b/src/test/groovy/com/moowork/gradle/RunWithMultipleGradleVersions.groovy
@@ -1,0 +1,16 @@
+package com.moowork.gradle
+
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.Retention
+import java.lang.annotation.Target
+
+import static java.lang.annotation.ElementType.METHOD
+import static java.lang.annotation.ElementType.TYPE
+import static java.lang.annotation.RetentionPolicy.RUNTIME
+
+@Retention(RUNTIME)
+@Target([METHOD, TYPE])
+@ExtensionAnnotation(RunWithMultipleGradleVersionsExtension.class)
+@interface RunWithMultipleGradleVersions {
+}

--- a/src/test/groovy/com/moowork/gradle/RunWithMultipleGradleVersionsExtension.groovy
+++ b/src/test/groovy/com/moowork/gradle/RunWithMultipleGradleVersionsExtension.groovy
@@ -1,0 +1,71 @@
+package com.moowork.gradle
+
+
+import org.gradle.util.GradleVersion
+import org.spockframework.runtime.extension.AbstractAnnotationDrivenExtension
+import org.spockframework.runtime.extension.IMethodInvocation
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.runtime.model.MethodInfo
+import org.spockframework.runtime.model.SpecInfo
+
+import java.lang.reflect.Parameter
+
+class RunWithMultipleGradleVersionsExtension extends AbstractAnnotationDrivenExtension<RunWithMultipleGradleVersions> {
+    private static final GradleVersion MINIMUM_SUPPORTED_GRADLE_VERSION = GradleVersion.version("5.0")
+    private static final GradleVersion CURRENT_GRADLE_VERSION = GradleVersion.current()
+    private static final GradleVersion[] GRADLE_VERSIONS = [MINIMUM_SUPPORTED_GRADLE_VERSION, CURRENT_GRADLE_VERSION]
+    private GradleVersion gradleVersion
+
+    @Override
+    void visitSpecAnnotation(RunWithMultipleGradleVersions annotation, SpecInfo spec) {
+        executeFeaturesWithAllGradleVersions(spec)
+        makeGradleVersionAvailableInTheSetupMethod(spec)
+    }
+
+    protected void executeFeaturesWithAllGradleVersions(SpecInfo spec) {
+        def bottomSpec = spec.getBottomSpec()
+        for (FeatureInfo feature : bottomSpec.getFeatures()) {
+            feature.setReportIterations(true)
+            feature.setIterationNameProvider({ "${gradleVersion}" })
+            feature.addInterceptor({ IMethodInvocation invocation ->
+                for (GradleVersion gradleVersion : GRADLE_VERSIONS) {
+                    println("Running with ${gradleVersion}")
+                    this.gradleVersion = gradleVersion
+                    invocation.proceed()
+                }
+            })
+        }
+    }
+
+    protected void makeGradleVersionAvailableInTheSetupMethod(SpecInfo spec) {
+        for (MethodInfo setupMethod : spec.getSetupMethods()) {
+            setupMethod.addInterceptor({ IMethodInvocation invocation ->
+                enrichParameters(invocation, gradleVersion)
+                invocation.proceed()
+            })
+        }
+    }
+
+    private void enrichParameters(IMethodInvocation invocation, GradleVersion gradleVersion) {
+        // Inspired from http://spockframework.org/spock/docs/1.3/extensions.html#_injecting_method_parameters
+        Map<Parameter, Integer> parameters = [:]
+        invocation.method.reflection.parameters.eachWithIndex { parameter, i ->
+            parameters << [(parameter): i]
+        }
+        parameters = parameters.findAll { GradleVersion.equals it.key.type }
+        // enlarge arguments array if necessary
+        def lastGradleVersionParameterIndex = parameters*.value.max()
+        lastGradleVersionParameterIndex = lastGradleVersionParameterIndex == null ?
+                0 :
+                lastGradleVersionParameterIndex + 1
+        if (invocation.arguments.length < lastGradleVersionParameterIndex) {
+            def newArguments = new Object[lastGradleVersionParameterIndex]
+            System.arraycopy(invocation.arguments, 0, newArguments, 0, invocation.arguments.length)
+            invocation.arguments = newArguments
+        }
+
+        parameters.each { parameter, i ->
+            invocation.arguments[i] = gradleVersion
+        }
+    }
+}


### PR DESCRIPTION
This pull request changes the test execution flow in order to get them executed on multiple Gradle versions (`5.0` and `5.6.2` for now) as requested in issue #4 .

It works but it dramatically increases the tests execution time. What else could we expect?

Do you think running with the lowest and highest supported version is a good choice? Do you think some tests would require to be also executed on specific intermediate versions?

Also, I could not get the iteration (the fact of running multiple times the same method with different configurations) name work. It prints the Gradle version in the Gradle output in order to easily know which version corresponds to iterations `0` and `1` (default naming).

I can adapt the Spock extension according to your feedback.