### PR TITLE
Fixed symlink for npx

### DIFF
--- a/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
+++ b/src/main/groovy/com/moowork/gradle/node/task/SetupTask.groovy
@@ -134,6 +134,11 @@ class SetupTask
             {
                 Files.createSymbolicLink( npm, Paths.get( variant.npmScriptFile ) )
             }
+            Path npx = Paths.get( variant.nodeBinDir.path, 'npx' )
+            if ( Files.deleteIfExists( npx ) )
+            {
+                Files.createSymbolicLink( npx, Paths.get( variant.npxScriptFile ) )
+            }
         }
     }
 


### PR DESCRIPTION
Fixes the `npx` symlink so that `NpxTask` works correctly (on mac)