### PR TITLE
relativize npm and npx symlinks

### DIFF
--- a/src/main/kotlin/com/moowork/gradle/node/task/SetupTask.kt
+++ b/src/main/kotlin/com/moowork/gradle/node/task/SetupTask.kt
@@ -85,11 +85,15 @@ open class SetupTask : DefaultTask() {
             // Fix broken symlink
             val npm = Paths.get(variant.nodeBinDir.path, "npm")
             if (Files.deleteIfExists(npm)) {
-                Files.createSymbolicLink(npm, Paths.get(variant.npmScriptFile))
+                Files.createSymbolicLink(
+                        npm,
+                        variant.nodeBinDir.toPath().relativize(Paths.get(variant.npmScriptFile)))
             }
             val npx = Paths.get(variant.nodeBinDir.path, "npx")
             if (Files.deleteIfExists(npx)) {
-                Files.createSymbolicLink(npx, Paths.get(variant.npxScriptFile))
+                Files.createSymbolicLink(
+                        npx,
+                        variant.nodeBinDir.toPath().relativize(Paths.get(variant.npxScriptFile)))
             }
         }
     }


### PR DESCRIPTION
Similar rationale as https://github.com/srs/gradle-node-plugin/commit/5a392ad45968da29c341404116fa907d41756b2c

We want to be able to make use of the unpacked node distribution in a place where the filesystem mapping is different, but seems this change didn't make it across to the kotlin rewrite.