### PR TITLE
Automatic proxy configuration fixes for  #113

### DIFF
--- a/src/main/kotlin/com/github/gradle/node/npm/exec/NpmExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/exec/NpmExecRunner.kt
@@ -5,6 +5,7 @@ import com.github.gradle.node.exec.ExecConfiguration
 import com.github.gradle.node.exec.ExecRunner
 import com.github.gradle.node.exec.NodeExecConfiguration
 import com.github.gradle.node.npm.proxy.NpmProxy.Companion.computeNpmProxyEnvironmentVariables
+import com.github.gradle.node.npm.proxy.NpmProxy.Companion.hasProxyConfiguration
 import com.github.gradle.node.util.zip
 import com.github.gradle.node.variant.VariantComputer
 import org.gradle.api.Project
@@ -24,7 +25,8 @@ internal class NpmExecRunner {
 
     private fun addProxyEnvironmentVariables(nodeExtension: NodeExtension,
                                              nodeExecConfiguration: NodeExecConfiguration): NodeExecConfiguration {
-        if (nodeExtension.useGradleProxySettings.get()) {
+        if (nodeExtension.useGradleProxySettings.get()
+                && !hasProxyConfiguration(nodeExecConfiguration.environment)) {
             val npmProxyEnvironmentVariables = computeNpmProxyEnvironmentVariables()
             if (npmProxyEnvironmentVariables.isNotEmpty()) {
                 val environmentVariables =

--- a/src/main/kotlin/com/github/gradle/node/npm/exec/NpmExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/exec/NpmExecRunner.kt
@@ -26,7 +26,7 @@ internal class NpmExecRunner {
     private fun addProxyEnvironmentVariables(nodeExtension: NodeExtension,
                                              nodeExecConfiguration: NodeExecConfiguration): NodeExecConfiguration {
         if (nodeExtension.useGradleProxySettings.get()
-                && !hasProxyConfiguration(nodeExecConfiguration.environment)) {
+                && !hasProxyConfiguration(System.getenv())) {
             val npmProxyEnvironmentVariables = computeNpmProxyEnvironmentVariables()
             if (npmProxyEnvironmentVariables.isNotEmpty()) {
                 val environmentVariables =

--- a/src/main/kotlin/com/github/gradle/node/npm/proxy/NpmProxy.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/proxy/NpmProxy.kt
@@ -6,13 +6,38 @@ import java.util.stream.Stream
 import kotlin.text.Charsets.UTF_8
 
 internal class NpmProxy {
+
     companion object {
+        // These are the environment variables that HTTPing applications checks, proxy is on and off.
+        // FTP skipped in hopes of a better future.
+        private val proxyVariables = listOf(
+                "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "PROXY"
+        )
+
+        // And since npm also takes settings in the form of environment variables with the
+        // NPM_CONFIG_<setting> format, we should check those. Hopefully nobody does this.
+        private val npmProxyVariables = listOf(
+                "NPM_CONFIG_PROXY", "NPM_CONFIG_HTTPS-PROXY", "NPM_CONFIG_NOPROXY"
+        )
+
         fun computeNpmProxyEnvironmentVariables(): Map<String, String> {
             val proxyEnvironmentVariables = computeProxyUrlEnvironmentVariables()
             if (proxyEnvironmentVariables.isNotEmpty()) {
                 addProxyIgnoredHostsEnvironmentVariable(proxyEnvironmentVariables)
             }
             return proxyEnvironmentVariables.toMap()
+        }
+
+        /**
+         * Returns true if the given map of environment variables already has
+         * proxy settings configured.
+         *
+         * @param env map of environment variables
+         */
+        fun hasProxyConfiguration(env: Map<String, String>): Boolean {
+            return env.keys.any {
+                proxyVariables.contains(it.toUpperCase()) || npmProxyVariables.contains(it.toUpperCase())
+            }
         }
 
         private fun computeProxyUrlEnvironmentVariables(): MutableMap<String, String> {

--- a/src/main/kotlin/com/github/gradle/node/npm/proxy/NpmProxy.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/proxy/NpmProxy.kt
@@ -27,9 +27,9 @@ internal class NpmProxy {
                     val proxyPassword = System.getProperty("$proxyProto.proxyPassword")
                     if (proxyUser != null && proxyPassword != null) {
                         proxyArgs[proxyParam] =
-                                "$proxyProto://${encode(proxyUser)}:${encode(proxyPassword)}@$proxyHost:$proxyPort"
+                                "http://${encode(proxyUser)}:${encode(proxyPassword)}@$proxyHost:$proxyPort"
                     } else {
-                        proxyArgs[proxyParam] = "$proxyProto://$proxyHost:$proxyPort"
+                        proxyArgs[proxyParam] = "http://$proxyHost:$proxyPort"
                     }
                 }
             }

--- a/src/main/kotlin/com/github/gradle/node/yarn/exec/YarnExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/exec/YarnExecRunner.kt
@@ -32,7 +32,7 @@ internal class YarnExecRunner {
     private fun addNpmProxyEnvironment(nodeExtension: NodeExtension,
                                        nodeExecConfiguration: NodeExecConfiguration): Map<String, String> {
         if (nodeExtension.useGradleProxySettings.get()
-                && !NpmProxy.hasProxyConfiguration(nodeExecConfiguration.environment)) {
+                && !NpmProxy.hasProxyConfiguration(System.getenv())) {
             val npmProxyEnvironmentVariables = NpmProxy.computeNpmProxyEnvironmentVariables()
             if (npmProxyEnvironmentVariables.isNotEmpty()) {
                 return nodeExecConfiguration.environment.plus(npmProxyEnvironmentVariables)

--- a/src/main/kotlin/com/github/gradle/node/yarn/exec/YarnExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/exec/YarnExecRunner.kt
@@ -31,7 +31,8 @@ internal class YarnExecRunner {
 
     private fun addNpmProxyEnvironment(nodeExtension: NodeExtension,
                                        nodeExecConfiguration: NodeExecConfiguration): Map<String, String> {
-        if (nodeExtension.useGradleProxySettings.get()) {
+        if (nodeExtension.useGradleProxySettings.get()
+                && !NpmProxy.hasProxyConfiguration(nodeExecConfiguration.environment)) {
             val npmProxyEnvironmentVariables = NpmProxy.computeNpmProxyEnvironmentVariables()
             if (npmProxyEnvironmentVariables.isNotEmpty()) {
                 return nodeExecConfiguration.environment.plus(npmProxyEnvironmentVariables)

--- a/src/test/groovy/com/github/gradle/AbstractIntegTest.groovy
+++ b/src/test/groovy/com/github/gradle/AbstractIntegTest.groovy
@@ -38,6 +38,12 @@ abstract class AbstractIntegTest extends Specification {
         return newRunner(args).build()
     }
 
+    protected final BuildResult buildWithEnvironment(Map<String, String> env, final String... args) {
+        return newRunner(args)
+                .withEnvironment(env)
+                .build()
+    }
+
     protected final BuildResult buildAndFail(final String... args) {
         return newRunner(args).buildAndFail()
     }

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmInstallTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmInstallTaskTest.groovy
@@ -25,7 +25,7 @@ class NpmInstallTaskTest extends AbstractTaskTest {
         then:
         1 * execSpec.setExecutable("npm")
         1 * execSpec.setArgs(["install"])
-        1 * execSpec.setEnvironment({ environment -> environment["HTTPS_PROXY"] == "https://my-super-proxy.net:11235" })
+        1 * execSpec.setEnvironment({ environment -> environment["HTTPS_PROXY"] == "http://my-super-proxy.net:11235" })
     }
 
     def "exec npm install task with configured proxy but disabled"() {

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmProxy_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmProxy_integTest.groovy
@@ -70,7 +70,8 @@ class NpmProxy_integTest extends AbstractIntegTest {
         copyResources("fixtures/npm-proxy/")
         copyResources("fixtures/proxy/")
         def proxyTestHelper = new ProxyTestHelper(projectDir)
-        def port = 443
+        def port = 80
+        // Intentionally write the wrong port to the file
         proxyTestHelper.writeGradleProperties(false, false, proxyMockServer.localPort+5,
                 null)
         proxyTestHelper.writeNpmConfiguration(false)
@@ -78,7 +79,10 @@ class NpmProxy_integTest extends AbstractIntegTest {
 
         when:
 
-        def result = buildWithEnvironment(["HTTP_PROXY": proxyAddress, "HTTPS_PROXY": proxyAddress]
+        Map<String, String> env = new HashMap<>()
+        env.putAll(System.getenv())
+        env.putAll(["HTTP_PROXY": proxyAddress, "HTTPS_PROXY": proxyAddress])
+        def result = buildWithEnvironment(env
                                           ,"npmInstall")
 
         then:

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmTaskTest.groovy
@@ -134,7 +134,7 @@ class NpmTaskTest extends AbstractTaskTest {
         then:
         1 * execSpec.setExecutable('npm')
         1 * execSpec.setArgs(['a', 'b'])
-        1 * execSpec.setEnvironment({ environment -> environment["HTTPS_PROXY"] == "https://my-super-proxy.net:11235" })
+        1 * execSpec.setEnvironment({ environment -> environment["HTTPS_PROXY"] == "http://my-super-proxy.net:11235" })
     }
 
     def "exec npm task with configured proxy but disabled"() {

--- a/src/test/groovy/com/github/gradle/node/yarn/task/YarnTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/yarn/task/YarnTaskTest.groovy
@@ -76,7 +76,7 @@ class YarnTaskTest extends AbstractTaskTest {
             return fixAbsolutePath(executable) == yarnExecutable.toAbsolutePath().toString()
         })
         1 * execSpec.setArgs(["run", "command"])
-        1 * execSpec.setEnvironment({ environment -> environment["HTTPS_PROXY"] == "https://me:password@1.2.3.4:443" })
+        1 * execSpec.setEnvironment({ environment -> environment["HTTPS_PROXY"] == "http://me:password@1.2.3.4:443" })
     }
 
     def "exec yarn task (download) with configured proxy but disabled"() {

--- a/src/test/kotlin/com/github/gradle/node/npm/proxy/NpmProxyTest.kt
+++ b/src/test/kotlin/com/github/gradle/node/npm/proxy/NpmProxyTest.kt
@@ -47,7 +47,7 @@ class NpmProxyTest {
 
         val result = NpmProxy.computeNpmProxyEnvironmentVariables()
 
-        assertThat(result).containsExactly(entry("HTTPS_PROXY", "https://1.2.3.4:8123"))
+        assertThat(result).containsExactly(entry("HTTPS_PROXY", "http://1.2.3.4:8123"))
     }
 
     @Test
@@ -59,7 +59,7 @@ class NpmProxyTest {
 
         val result = NpmProxy.computeNpmProxyEnvironmentVariables()
 
-        assertThat(result).containsExactly(entry("HTTPS_PROXY", "https://me%2Fyou:p%40ssword@4.3.2.1:1234"))
+        assertThat(result).containsExactly(entry("HTTPS_PROXY", "http://me%2Fyou:p%40ssword@4.3.2.1:1234"))
     }
 
     @Test
@@ -75,7 +75,7 @@ class NpmProxyTest {
 
         assertThat(result).containsExactly(
                 entry("HTTP_PROXY", "http://4.3.2.1:1234"),
-                entry("HTTPS_PROXY", "https://me%2Fyou:p%40ssword@1.2.3.4:4321"))
+                entry("HTTPS_PROXY", "http://me%2Fyou:p%40ssword@1.2.3.4:4321"))
     }
 
     @Test
@@ -101,7 +101,7 @@ class NpmProxyTest {
 
         assertThat(result).containsExactly(
                 entry("HTTP_PROXY", "http://4.3.2.1:80"),
-                entry("HTTPS_PROXY", "https://1.2.3.4:443"))
+                entry("HTTPS_PROXY", "http://1.2.3.4:443"))
     }
 
     @Test
@@ -123,7 +123,7 @@ class NpmProxyTest {
 
         assertThat(result).containsExactly(
                 entry("HTTP_PROXY", "http://me:pass@4.3.2.1:80"),
-                entry("HTTPS_PROXY", "https://you:word@1.2.3.4:443"),
+                entry("HTTPS_PROXY", "http://you:word@1.2.3.4:443"),
                 entry("NO_PROXY", "host.com, anotherHost.com, sameProtocol.com, yetAnotherHost.com"))
     }
 

--- a/src/test/kotlin/com/github/gradle/node/npm/proxy/NpmProxyTest.kt
+++ b/src/test/kotlin/com/github/gradle/node/npm/proxy/NpmProxyTest.kt
@@ -136,4 +136,16 @@ class NpmProxyTest {
 
         assertThat(result).isEmpty()
     }
+
+    @Test
+    internal fun shouldNotConfigureEnvironmentVariables() {
+        assertThat(NpmProxy.hasProxyConfiguration(getEnv("HTTP_PROXY"))).isTrue
+        assertThat(NpmProxy.hasProxyConfiguration(getEnv("proXy"))).isTrue
+        assertThat(NpmProxy.hasProxyConfiguration(getEnv("NPM_CONFIG_PROXY"))).isTrue
+        assertThat(NpmProxy.hasProxyConfiguration(getEnv("HELLO"))).isFalse
+    }
+
+    private fun getEnv(key: String): Map<String, String> {
+        return mapOf(key to "yes")
+    }
 }

--- a/src/test/resources/fixtures/javascript-project/package.json
+++ b/src/test/resources/fixtures/javascript-project/package.json
@@ -1,7 +1,7 @@
 {
   "name": "hello",
   "dependencies": {
-    "mocha": "6.2.0",
+    "mocha": "8.2.0",
     "chai": "4.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
* Makes the URL in `HTTP_PROXY` and `HTTPS_PROXY` into `http://` to match the most common setup.
* Prevents automatic proxy configuration if there's already existing proxy configuration in environment variables
  - [x] Add test for npm
  - [x] Add test for yarn
  - [x] Check if yarn has something like `NPM_CONFIG_<setting>`
