### PR TITLE
Add tests and support for npm >= 7 fixes #123

### DIFF
--- a/src/main/kotlin/com/github/gradle/node/npm/task/NpmSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/task/NpmSetupTask.kt
@@ -13,6 +13,7 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.listProperty
+import java.io.File
 
 /**
  * npm install that only gets executed if gradle decides so.
@@ -65,7 +66,7 @@ open class NpmSetupTask : DefaultTask() {
         val version = nodeExtension.npmVersion.get()
         val directory = npmDir.get().asFile
         // npm < 7 creates the directory if it's missing, >= 7 fails if it's missing
-        directory.mkdirs()
+        File(directory, "lib").mkdirs()
         return listOf("install", "--global", "--no-save", "--prefix", directory.absolutePath,
                 "npm@$version") + args.get()
     }

--- a/src/main/kotlin/com/github/gradle/node/yarn/task/YarnSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/task/YarnSetupTask.kt
@@ -6,6 +6,7 @@ import com.github.gradle.node.variant.VariantComputer
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
+import java.io.File
 
 /**
  * Setup a specific version of Yarn to be used by the build.
@@ -33,7 +34,7 @@ open class YarnSetupTask : NpmSetupTask() {
         val yarnPackage = if (version.isNotBlank()) "yarn@$version" else "yarn"
         // npm < 7 creates the directory if it's missing, >= 7 fails if it's missing
         // create the directory since we use npm to install yarn.
-        yarnDir.asFile.mkdirs()
+        File(yarnDir.asFile, "lib").mkdirs()
         return listOf("install", "--global", "--no-save", "--prefix", yarnDir.asFile.absolutePath, yarnPackage)
                 .plus(args.get())
     }

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
@@ -39,6 +39,28 @@ class NpmInstall_integTest extends AbstractIntegTest {
         result.task(":npmInstall").outcome == TaskOutcome.UP_TO_DATE
     }
 
+    def 'install packages with npm >= 7'() {
+        given:
+        writeBuild('''
+            plugins {
+                id 'com.github.node-gradle.node'
+            }
+            
+            node {
+                download = true
+                version = '15.2.1'
+                npmVersion = '7.0.1'
+            }
+        ''')
+        writeEmptyPackageJson()
+
+        when:
+        def result = build('npmInstall')
+
+        then:
+        result.task(":npmInstall").outcome == TaskOutcome.SUCCESS
+    }
+
     def 'install packages with npm and postinstall task requiring npm and node'() {
         given:
         writeBuild('''

--- a/src/test/groovy/com/github/gradle/node/yarn/task/YarnInstall_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/yarn/task/YarnInstall_integTest.groovy
@@ -36,6 +36,41 @@ class YarnInstall_integTest extends AbstractIntegTest {
         result.outcome == TaskOutcome.UP_TO_DATE
     }
 
+    def 'install packages with yarn on npm >= 7'() {
+        given:
+        writeBuild('''
+            plugins {
+                id 'com.github.node-gradle.node'
+            }
+
+            node {
+                download = true
+                yarnWorkDir = file('build/yarn')
+                version = '15.2.1'
+                npmVersion = '7.0.1'
+            }
+        ''')
+        writeEmptyPackageJson()
+
+        when:
+        def result = buildTask('yarn')
+
+        then:
+        result.outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = buildTask('yarn')
+
+        then:
+        result.outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = buildTask('yarn')
+
+        then:
+        result.outcome == TaskOutcome.UP_TO_DATE
+    }
+
     def 'install packages with yarn and and postinstall task requiring node and yarn'() {
         given:
         writeBuild('''


### PR DESCRIPTION
This adds a simple test for npm and yarn that checks that installation works on npm 7 and greater.

It's `download = true` to make sure that we run on new enough versions.