### PR TITLE
Configuration cache support

### DIFF
--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -13,6 +13,8 @@ jobs:
       - name: Gradle Version
         run: ./gradlew --version
       - name: Build Node.js Scripts Project
-        run: ./gradlew -p examples/simple-node helloWorld
+        run: ./gradlew -p examples/simple-node helloWorld --configuration-cache
       - name: Build Spring Boot Angular Project
-        run: ./gradlew -p examples/spring-boot-angular build
+        run: ./gradlew -p examples/spring-boot-angular build --configuration-cache
+      - name: Rebuild Spring Boot Angular Project to Reuse the Configuration Cache
+        run: ./gradlew -p examples/spring-boot-angular build --configuration-cache

--- a/.github/workflows/build-examples.yml
+++ b/.github/workflows/build-examples.yml
@@ -13,8 +13,6 @@ jobs:
       - name: Gradle Version
         run: ./gradlew --version
       - name: Build Node.js Scripts Project
-        run: ./gradlew -p examples/simple-node helloWorld --configuration-cache
+        run: ./gradlew -p examples/simple-node helloWorld
       - name: Build Spring Boot Angular Project
-        run: ./gradlew -p examples/spring-boot-angular build --configuration-cache
-      - name: Rebuild Spring Boot Angular Project to Reuse the Configuration Cache
-        run: ./gradlew -p examples/spring-boot-angular build --configuration-cache
+        run: ./gradlew -p examples/spring-boot-angular build

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,6 +61,8 @@ tasks.test {
     useJUnitPlatform()
     if (project.hasProperty("skipIT")) {
         exclude("**/*_integTest*")
+    } else if (project.hasProperty("onlyIT")) {
+        include("**/*_integTest*")
     }
     systemProperty("testAllSupportedGradleVersions", project.properties["testAllSupportedGradleVersions"] ?: "false")
     systemProperty("testMinimumSupportedGradleVersion", project.properties["testMinimumSupportedGradleVersion"] ?: "false")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,8 @@ tasks.test {
         include("**/*_integTest*")
     }
     systemProperty("testAllSupportedGradleVersions", project.properties["testAllSupportedGradleVersions"] ?: "false")
-    systemProperty("testMinimumSupportedGradleVersion", project.properties["testMinimumSupportedGradleVersion"] ?: "false")
+    systemProperty("testMinimumSupportedGradleVersion", project.properties["testMinimumSupportedGradleVersion"]
+            ?: "false")
     systemProperty("testMinimumCurrentGradleVersion", project.properties["testMinimumCurrentGradleVersion"] ?: "false")
     systemProperty("testCurrentGradleVersion", project.properties["testCurrentGradleVersion"] ?: "true")
 

--- a/examples/spring-boot-angular/build.gradle.kts
+++ b/examples/spring-boot-angular/build.gradle.kts
@@ -10,7 +10,7 @@ buildscript {
 
 plugins {
     java
-    id("org.springframework.boot") version "2.3.3.RELEASE"
+    id("org.springframework.boot") version "2.4.2"
 }
 
 repositories {
@@ -22,9 +22,10 @@ dependencies {
     implementation(project(":webapp"))
     implementation("org.springframework.boot:spring-boot-starter-web")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    testImplementation("io.github.bonigarcia:webdrivermanager:3.8.1")
+    testImplementation("io.github.bonigarcia:webdrivermanager:4.3.1")
     testImplementation("org.seleniumhq.selenium:selenium-java")
     testImplementation("org.junit.jupiter:junit-jupiter-api")
+    testImplementation("org.assertj:assertj-core")
     testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine")
 }
 

--- a/examples/spring-boot-angular/src/test/java/com/github/gradle/node/WebappTest.java
+++ b/examples/spring-boot-angular/src/test/java/com/github/gradle/node/WebappTest.java
@@ -12,7 +12,7 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static io.github.bonigarcia.wdm.WebDriverManager.firefoxdriver;
-import static org.junit.Assert.assertEquals;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 @ExtendWith(SpringExtension.class)
@@ -34,8 +34,8 @@ class WebappTest {
     void shouldServeWebapp() {
         String url = "http://localhost:" + port + "/";
         firefoxDriver.get(url);
-        assertEquals("webapp app is running!",
-                firefoxDriver.findElement(By.cssSelector(".card.highlight-card span")).getText());
+        assertThat(firefoxDriver.findElement(By.cssSelector(".card.highlight-card span")).getText())
+                .isEqualTo("webapp app is running!");
     }
 
     @AfterEach

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.6.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-rc-1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-rc-1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.8-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/kotlin/com/github/gradle/node/NodePlugin.kt
+++ b/src/main/kotlin/com/github/gradle/node/NodePlugin.kt
@@ -24,7 +24,9 @@ class NodePlugin : Plugin<Project> {
         addNpmRule()
         addYarnRule()
         project.afterEvaluate {
-            ext.distBaseUrl.orNull?.let { addRepository(it) }
+            if (ext.download.get()) {
+                ext.distBaseUrl.orNull?.let { addRepository(it) }
+            }
         }
     }
 

--- a/src/main/kotlin/com/github/gradle/node/NodePlugin.kt
+++ b/src/main/kotlin/com/github/gradle/node/NodePlugin.kt
@@ -6,26 +6,30 @@ import com.github.gradle.node.npm.task.NpmTask
 import com.github.gradle.node.npm.task.NpxTask
 import com.github.gradle.node.task.NodeSetupTask
 import com.github.gradle.node.task.NodeTask
+import com.github.gradle.node.variant.VariantComputer
 import com.github.gradle.node.yarn.task.YarnInstallTask
 import com.github.gradle.node.yarn.task.YarnSetupTask
 import com.github.gradle.node.yarn.task.YarnTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.kotlin.dsl.named
 import org.gradle.kotlin.dsl.register
+import java.io.File
 
 class NodePlugin : Plugin<Project> {
     private lateinit var project: Project
 
     override fun apply(project: Project) {
         this.project = project
-        val ext = NodeExtension.create(project)
+        val nodeExtension = NodeExtension.create(project)
         addGlobalTypes()
         addTasks()
         addNpmRule()
         addYarnRule()
         project.afterEvaluate {
-            if (ext.download.get()) {
-                ext.distBaseUrl.orNull?.let { addRepository(it) }
+            if (nodeExtension.download.get()) {
+                nodeExtension.distBaseUrl.orNull?.let { addRepository(it) }
+                configureNodeSetupTask(nodeExtension)
             }
         }
     }
@@ -90,6 +94,25 @@ class NodePlugin : Plugin<Project> {
                 artifact()
             }
         }
+    }
+
+    private fun configureNodeSetupTask(nodeExtension: NodeExtension) {
+        val variantComputer = VariantComputer()
+        val nodeArchiveDependencyProvider = variantComputer.computeNodeArchiveDependency(nodeExtension)
+        val archiveFileProvider = nodeArchiveDependencyProvider
+                .map { nodeArchiveDependency ->
+                    resolveNodeArchiveFile(nodeArchiveDependency)
+                }
+        project.tasks.named<NodeSetupTask>(NodeSetupTask.NAME) {
+            nodeArchiveFile.set(project.layout.file(archiveFileProvider))
+        }
+    }
+
+    private fun resolveNodeArchiveFile(name: String): File {
+        val dependency = project.dependencies.create(name)
+        val configuration = project.configurations.detachedConfiguration(dependency)
+        configuration.isTransitive = false
+        return configuration.resolve().single()
     }
 
     companion object {

--- a/src/main/kotlin/com/github/gradle/node/NodePlugin.kt
+++ b/src/main/kotlin/com/github/gradle/node/NodePlugin.kt
@@ -18,11 +18,14 @@ class NodePlugin : Plugin<Project> {
 
     override fun apply(project: Project) {
         this.project = project
-        NodeExtension.create(project)
+        val ext = NodeExtension.create(project)
         addGlobalTypes()
         addTasks()
         addNpmRule()
         addYarnRule()
+        project.afterEvaluate {
+            ext.distBaseUrl.orNull?.let { addRepository(it) }
+        }
     }
 
     private fun addGlobalTypes() {
@@ -70,6 +73,19 @@ class NodePlugin : Plugin<Project> {
                         dependsOn(YarnInstallTask.NAME)
                     }
                 }
+            }
+        }
+    }
+
+    private fun addRepository(distUrl: String) {
+        project.repositories.ivy {
+            setUrl(distUrl)
+            patternLayout {
+                artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]")
+                ivy("v[revision]/ivy.xml")
+            }
+            metadataSources {
+                artifact()
             }
         }
     }

--- a/src/main/kotlin/com/github/gradle/node/exec/ExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/exec/ExecRunner.kt
@@ -6,8 +6,8 @@ import org.gradle.api.file.DirectoryProperty
 import java.io.File
 
 internal class ExecRunner {
-    fun execute(project: ProjectApiHelper, extension: NodeExtension,  execConfiguration: ExecConfiguration) {
-        project.exec {
+    fun execute(projectHelper: ProjectApiHelper, extension: NodeExtension, execConfiguration: ExecConfiguration) {
+        projectHelper.exec {
             executable = execConfiguration.executable
             args = execConfiguration.args
             environment = computeEnvironment(execConfiguration)

--- a/src/main/kotlin/com/github/gradle/node/exec/ExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/exec/ExecRunner.kt
@@ -1,17 +1,18 @@
 package com.github.gradle.node.exec
 
 import com.github.gradle.node.NodeExtension
-import org.gradle.api.Project
+import com.github.gradle.node.util.ProjectApiHelper
+import org.gradle.api.file.DirectoryProperty
 import java.io.File
 
 internal class ExecRunner {
-    fun execute(project: Project, execConfiguration: ExecConfiguration) {
+    fun execute(project: ProjectApiHelper, extension: NodeExtension,  execConfiguration: ExecConfiguration) {
         project.exec {
             executable = execConfiguration.executable
             args = execConfiguration.args
             environment = computeEnvironment(execConfiguration)
             isIgnoreExitValue = execConfiguration.ignoreExitValue
-            workingDir = computeWorkingDir(project, execConfiguration)
+            workingDir = computeWorkingDir(extension.nodeProjectDir, execConfiguration)
             execConfiguration.execOverrides?.execute(this)
         }
     }
@@ -32,9 +33,8 @@ internal class ExecRunner {
         return execEnvironment
     }
 
-    private fun computeWorkingDir(project: Project, execConfiguration: ExecConfiguration): File? {
-        val nodeExtension = NodeExtension[project]
-        val workingDir = execConfiguration.workingDir ?: nodeExtension.nodeProjectDir.get().asFile
+    private fun computeWorkingDir(nodeProjectDir: DirectoryProperty, execConfiguration: ExecConfiguration): File? {
+        val workingDir = execConfiguration.workingDir ?: nodeProjectDir.get().asFile
         workingDir.mkdirs()
         return workingDir
     }

--- a/src/main/kotlin/com/github/gradle/node/exec/NodeExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/exec/NodeExecRunner.kt
@@ -1,22 +1,21 @@
 package com.github.gradle.node.exec
 
 import com.github.gradle.node.NodeExtension
+import com.github.gradle.node.util.ProjectApiHelper
 import com.github.gradle.node.util.zip
 import com.github.gradle.node.variant.VariantComputer
-import org.gradle.api.Project
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 
 internal class NodeExecRunner {
-    fun execute(project: Project, nodeExecConfiguration: NodeExecConfiguration) {
-        val execConfiguration = buildExecConfiguration(project, nodeExecConfiguration).get()
+    fun execute(project: ProjectApiHelper, extension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration) {
+        val execConfiguration = buildExecConfiguration(extension, nodeExecConfiguration).get()
         val execRunner = ExecRunner()
-        execRunner.execute(project, execConfiguration)
+        execRunner.execute(project, extension, execConfiguration)
     }
 
-    private fun buildExecConfiguration(project: Project, nodeExecConfiguration: NodeExecConfiguration):
+    private fun buildExecConfiguration(nodeExtension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration):
             Provider<ExecConfiguration> {
-        val nodeExtension = NodeExtension[project]
         val variantComputer = VariantComputer()
         val nodeDirProvider = variantComputer.computeNodeDir(nodeExtension)
         val nodeBinDirProvider = variantComputer.computeNodeBinDir(nodeDirProvider)

--- a/src/main/kotlin/com/github/gradle/node/npm/task/NpmInstallTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/task/NpmInstallTask.kt
@@ -1,6 +1,5 @@
 package com.github.gradle.node.npm.task
 
-import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.util.zip
 import org.gradle.api.Action

--- a/src/main/kotlin/com/github/gradle/node/npm/task/NpmInstallTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/task/NpmInstallTask.kt
@@ -80,8 +80,7 @@ abstract class NpmInstallTask : NpmTask() {
                 .flatMap { (nodeModulesDirectory, nodeModulesOutputFilter) ->
                     if (nodeModulesOutputFilter != null) {
                         val fileTree = projectHelper.fileTree(nodeModulesDirectory)
-                        //TODO: have a closer look at this.
-                        nodeModulesOutputFilter.execute(fileTree!!)
+                        nodeModulesOutputFilter.execute(fileTree)
                         providers.provider { fileTree }
                     } else providers.provider { null }
                 }

--- a/src/main/kotlin/com/github/gradle/node/npm/task/NpmInstallTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/task/NpmInstallTask.kt
@@ -16,12 +16,10 @@ import java.io.File
 /**
  * npm install that only gets executed if gradle decides so.
  */
-open class NpmInstallTask : NpmTask() {
-    private val nodeExtension by lazy { NodeExtension[project] }
-
+abstract class NpmInstallTask : NpmTask() {
     @get:Internal
     val nodeModulesOutputFilter =
-            project.objects.property<Action<ConfigurableFileTree>>()
+            objects.property<Action<ConfigurableFileTree>>()
 
     init {
         group = NodePlugin.NPM_GROUP
@@ -48,7 +46,7 @@ open class NpmInstallTask : NpmTask() {
     @InputFile
     protected fun getPackageLockFileAsInput(): Provider<File> {
         return npmCommand.flatMap { command ->
-            if (command[0] == "ci") projectFileIfExists("package-lock.json") else project.provider { null }
+            if (command[0] == "ci") projectFileIfExists("package-lock.json") else providers.provider { null }
         }
     }
 
@@ -56,13 +54,13 @@ open class NpmInstallTask : NpmTask() {
     @OutputFile
     protected fun getPackageLockFileAsOutput(): Provider<File> {
         return npmCommand.flatMap { command ->
-            if (command[0] == "install") projectFileIfExists("package-lock.json") else project.provider { null }
+            if (command[0] == "install") projectFileIfExists("package-lock.json") else providers.provider { null }
         }
     }
 
     private fun projectFileIfExists(name: String): Provider<File> {
         return nodeExtension.nodeProjectDir.map { it.file(name).asFile }
-                .flatMap { if (it.exists()) project.providers.provider { it } else project.providers.provider { null } }
+                .flatMap { if (it.exists()) providers.provider { it } else providers.provider { null } }
     }
 
     @Optional
@@ -71,7 +69,7 @@ open class NpmInstallTask : NpmTask() {
     protected fun getNodeModulesDirectory(): Provider<Directory> {
         val filter = nodeModulesOutputFilter.orNull
         return if (filter == null) nodeExtension.nodeProjectDir.dir("node_modules")
-        else project.providers.provider { null }
+        else providers.provider { null }
     }
 
     @Optional
@@ -82,10 +80,11 @@ open class NpmInstallTask : NpmTask() {
         return zip(nodeModulesDirectoryProvider, nodeModulesOutputFilter)
                 .flatMap { (nodeModulesDirectory, nodeModulesOutputFilter) ->
                     if (nodeModulesOutputFilter != null) {
-                        val fileTree = project.fileTree(nodeModulesDirectory)
-                        nodeModulesOutputFilter.execute(fileTree)
-                        project.providers.provider { fileTree }
-                    } else project.providers.provider { null }
+                        val fileTree = projectHelper.fileTree(nodeModulesDirectory)
+                        //TODO: have a closer look at this.
+                        nodeModulesOutputFilter.execute(fileTree!!)
+                        providers.provider { fileTree }
+                    } else providers.provider { null }
                 }
     }
 

--- a/src/main/kotlin/com/github/gradle/node/npm/task/NpmSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/task/NpmSetupTask.kt
@@ -40,7 +40,7 @@ abstract class NpmSetupTask : DefaultTask() {
     val args = objects.listProperty<String>()
 
     @get:Input
-    val download by lazy { nodeExtension.download }
+    val download = nodeExtension.download
 
     @get:OutputDirectory
     val npmDir by lazy {

--- a/src/main/kotlin/com/github/gradle/node/npm/task/NpmTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/task/NpmTask.kt
@@ -1,10 +1,14 @@
 package com.github.gradle.node.npm.task
 
+import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.exec.NodeExecConfiguration
 import com.github.gradle.node.npm.exec.NpmExecRunner
+import com.github.gradle.node.util.ProjectApiHelper
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -13,27 +17,40 @@ import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 import org.gradle.process.ExecSpec
+import javax.inject.Inject
 
-open class NpmTask : DefaultTask() {
+abstract class NpmTask : DefaultTask() {
+    @get:Inject
+    abstract val objects: ObjectFactory
+
+    @get:Inject
+    abstract val providers: ProviderFactory
+
     @get:Optional
     @get:Input
-    val npmCommand = project.objects.listProperty<String>()
+    val npmCommand = objects.listProperty<String>()
 
     @get:Optional
     @get:Input
-    val args = project.objects.listProperty<String>()
+    val args = objects.listProperty<String>()
 
     @get:Input
-    val ignoreExitValue = project.objects.property<Boolean>().convention(false)
+    val ignoreExitValue = objects.property<Boolean>().convention(false)
 
     @get:Internal
-    val workingDir = project.objects.fileProperty()
+    val workingDir = objects.fileProperty()
 
     @get:Input
-    val environment = project.objects.mapProperty<String, String>()
+    val environment = objects.mapProperty<String, String>()
 
     @get:Internal
-    val execOverrides = project.objects.property<Action<ExecSpec>>()
+    val execOverrides = objects.property<Action<ExecSpec>>()
+
+    @get:Internal
+    val projectHelper = ProjectApiHelper.newInstance(project)
+
+    @get:Internal
+    val nodeExtension = NodeExtension[project]
 
     init {
         group = NodePlugin.NPM_GROUP
@@ -52,7 +69,7 @@ open class NpmTask : DefaultTask() {
         val nodeExecConfiguration =
                 NodeExecConfiguration(command, environment.get(), workingDir.asFile.orNull, ignoreExitValue.get(),
                         execOverrides.orNull)
-        val npmExecRunner = NpmExecRunner()
-        npmExecRunner.executeNpmCommand(project, nodeExecConfiguration)
+        val npmExecRunner = objects.newInstance(NpmExecRunner::class.java)
+        npmExecRunner.executeNpmCommand(projectHelper, nodeExtension, nodeExecConfiguration)
     }
 }

--- a/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
@@ -5,14 +5,24 @@ import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.util.PlatformHelper
 import com.github.gradle.node.variant.VariantComputer
 import org.gradle.api.DefaultTask
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 import java.nio.file.Files
 import java.nio.file.Paths
+import javax.inject.Inject
 
-open class NodeSetupTask : DefaultTask() {
+abstract class NodeSetupTask : DefaultTask() {
+
+    @get:Inject
+    abstract val objects: ObjectFactory
+
+    @get:Inject
+    abstract val providers: ProviderFactory
+
     private val variantComputer = VariantComputer()
     private val nodeExtension = NodeExtension[project]
 

--- a/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
@@ -73,7 +73,7 @@ abstract class NodeSetupTask : DefaultTask() {
         val nodeBinDirProvider = variantComputer.computeNodeBinDir(nodeDirProvider)
         if (nodeArchiveFile.name.endsWith("zip")) {
             projectHelper.copy {
-                from(project.zipTree(nodeArchiveFile))
+                from(projectHelper.zipTree(nodeArchiveFile))
                 into(nodeDirProvider.map { it.dir("../") })
             }
         } else {

--- a/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
@@ -29,7 +29,7 @@ abstract class NodeSetupTask : DefaultTask() {
     private val nodeExtension = NodeExtension[project]
 
     @get:Input
-    val download by lazy { nodeExtension.download }
+    val download = nodeExtension.download
 
     @get:Input
     val archiveDependency by lazy {

--- a/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
@@ -54,7 +54,6 @@ abstract class NodeSetupTask : DefaultTask() {
 
     @TaskAction
     fun exec() {
-        addRepositoryIfNeeded()
         val archiveDependency = variantComputer.computeArchiveDependency(nodeExtension).get()
         deleteExistingNode()
         unpackNodeArchive(archiveDependency)
@@ -113,23 +112,6 @@ abstract class NodeSetupTask : DefaultTask() {
         val conf = project.configurations.detachedConfiguration(dep)
         conf.isTransitive = false
         return conf.resolve().single()
-    }
-
-    private fun addRepositoryIfNeeded() {
-        nodeExtension.distBaseUrl.orNull?.let { addRepository(it) }
-    }
-
-    private fun addRepository(distUrl: String) {
-        project.repositories.ivy {
-            setUrl(distUrl)
-            patternLayout {
-                artifact("v[revision]/[artifact](-v[revision]-[classifier]).[ext]")
-                ivy("v[revision]/ivy.xml")
-            }
-            metadataSources {
-                artifact()
-            }
-        }
     }
 
     companion object {

--- a/src/main/kotlin/com/github/gradle/node/task/NodeTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/task/NodeTask.kt
@@ -1,39 +1,56 @@
 package com.github.gradle.node.task
 
+import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.exec.NodeExecConfiguration
 import com.github.gradle.node.exec.NodeExecRunner
+import com.github.gradle.node.util.ProjectApiHelper
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.*
 import org.gradle.api.tasks.PathSensitivity.RELATIVE
 import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 import org.gradle.process.ExecSpec
+import javax.inject.Inject
 
-open class NodeTask : DefaultTask() {
+abstract class NodeTask : DefaultTask() {
+    @get:Inject
+    abstract val objects: ObjectFactory
+
+    @get:Inject
+    abstract val providers: ProviderFactory
+
     @get:InputFile
     @get:PathSensitive(RELATIVE)
-    val script = project.objects.fileProperty()
+    val script = objects.fileProperty()
 
     @get:Input
-    val options = project.objects.listProperty<String>()
+    val options = objects.listProperty<String>()
 
     @get:Input
-    val args = project.objects.listProperty<String>()
+    val args = objects.listProperty<String>()
 
     @get:Input
-    val ignoreExitValue = project.objects.property<Boolean>().convention(false)
+    val ignoreExitValue = objects.property<Boolean>().convention(false)
 
     @get:Internal
-    val workingDir = project.objects.directoryProperty()
+    val workingDir = objects.directoryProperty()
 
     @get:Input
-    val environment = project.objects.mapProperty<String, String>()
+    val environment = objects.mapProperty<String, String>()
 
     @get:Internal
-    val execOverrides = project.objects.property<Action<ExecSpec>>()
+    val execOverrides = objects.property<Action<ExecSpec>>()
+
+    @get:Internal
+    val projectHelper = ProjectApiHelper.newInstance(project)
+
+    @get:Internal
+    val extension = NodeExtension[project]
 
     init {
         group = NodePlugin.NODE_GROUP
@@ -54,6 +71,6 @@ open class NodeTask : DefaultTask() {
                 NodeExecConfiguration(command, environment.get(), workingDir.asFile.orNull,
                         ignoreExitValue.get(), execOverrides.orNull)
         val nodeExecRunner = NodeExecRunner()
-        nodeExecRunner.execute(project, nodeExecConfiguration)
+        nodeExecRunner.execute(projectHelper, extension, nodeExecConfiguration)
     }
 }

--- a/src/main/kotlin/com/github/gradle/node/util/ProjectApiHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/ProjectApiHelper.kt
@@ -32,6 +32,8 @@ interface ProjectApiHelper {
 
     fun fileTree(directory: Directory): ConfigurableFileTree
 
+    fun zipTree(tarPath: File): FileTree
+
     fun tarTree(tarPath: File): FileTree
 
     fun copy(action: Action<CopySpec>): WorkResult
@@ -49,6 +51,10 @@ internal open class DefaultProjectApiHelper @Inject constructor(
 
     override fun fileTree(directory: Directory): ConfigurableFileTree {
         return factory.fileTree().from(directory)
+    }
+
+    override fun zipTree(tarPath: File): FileTree {
+        return archiveOperations.zipTree(tarPath)
     }
 
     override fun tarTree(tarPath: File): FileTree {
@@ -72,6 +78,10 @@ internal open class LegacyProjectApiHelper(private val project: Project) : Proje
 
     override fun fileTree(directory: Directory): ConfigurableFileTree {
         return project.fileTree(directory)
+    }
+
+    override fun zipTree(tarPath: File): FileTree {
+        return project.zipTree(tarPath)
     }
 
     override fun tarTree(tarPath: File): FileTree {

--- a/src/main/kotlin/com/github/gradle/node/util/ProjectApiHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/ProjectApiHelper.kt
@@ -1,0 +1,93 @@
+@file:Suppress("UnstableApiUsage")
+
+package com.github.gradle.node.util
+
+import org.gradle.api.Action
+import org.gradle.api.Project
+import org.gradle.api.file.ConfigurableFileTree
+import org.gradle.api.file.Directory
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.model.ObjectFactory
+import org.gradle.process.ExecOperations
+import org.gradle.process.ExecResult
+import org.gradle.process.ExecSpec
+import org.gradle.util.GradleVersion
+import java.io.File
+import javax.inject.Inject
+
+
+abstract class ProjectApiHelper {
+    companion object {
+        @JvmStatic
+        fun newInstance(project: Project): ProjectApiHelper {
+            return if (enableConfigurationCache()) {
+                project.objects.newInstance(DefaultProjectApiHelper::class.java)
+            } else {
+                LegacyProjectApiHelper(project)
+            }
+        }
+
+        inline fun enableConfigurationCache(): Boolean {
+            return GradleVersion.current() >= GradleVersion.version("6.6")
+        }
+
+    }
+    abstract fun fileTree(directory: Directory?): ConfigurableFileTree?
+
+    abstract fun exec(closure: Action<ExecSpec?>?): ExecResult?
+}
+
+internal open class DefaultProjectApiHelper @Inject constructor(
+        private val factory: ObjectFactory,
+        private val layout: ProjectLayout,
+        private val execOperations: ExecOperations) : ProjectApiHelper() {
+
+    val buildDirectory: File
+        get() = layout.buildDirectory.get().asFile
+
+    fun file(path: String?): File? {
+        return if (path != null) {
+            layout.projectDirectory.file(path).asFile
+        } else {
+            null
+        }
+    }
+
+    fun file(file: File): File? {
+        return file(file.path)
+    }
+
+    override fun fileTree(directory: Directory?): ConfigurableFileTree? {
+        return directory?.let { factory.fileTree().from(it) }
+    }
+
+    override fun exec(closure: Action<ExecSpec?>?): ExecResult {
+        return execOperations.exec(closure)
+    }
+
+}
+
+internal open class LegacyProjectApiHelper(private val project: Project) : ProjectApiHelper() {
+    val buildDirectory: File
+        get() = project.buildDir
+
+    fun file(path: String?): File? {
+        return path?.let { project.file(it) }
+    }
+
+    fun file(file: File?): File? {
+        return if (file != null) {
+            project.file(file)
+        } else {
+            null
+        }
+    }
+
+    override fun fileTree(directory: Directory?): ConfigurableFileTree? {
+        return directory?.let { project.fileTree(it) }
+    }
+
+    override fun exec(closure: Action<ExecSpec?>?): ExecResult? {
+        return closure?.let { project.exec(it) }
+    }
+}

--- a/src/main/kotlin/com/github/gradle/node/util/ProjectApiHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/ProjectApiHelper.kt
@@ -15,7 +15,6 @@ import org.gradle.util.GradleVersion
 import java.io.File
 import javax.inject.Inject
 
-
 abstract class ProjectApiHelper {
     companion object {
         @JvmStatic
@@ -27,11 +26,11 @@ abstract class ProjectApiHelper {
             }
         }
 
-        inline fun enableConfigurationCache(): Boolean {
+        private fun enableConfigurationCache(): Boolean {
             return GradleVersion.current() >= GradleVersion.version("6.6")
         }
-
     }
+
     abstract fun fileTree(directory: Directory?): ConfigurableFileTree?
 
     abstract fun exec(closure: Action<ExecSpec?>?): ExecResult?
@@ -64,7 +63,6 @@ internal open class DefaultProjectApiHelper @Inject constructor(
     override fun exec(closure: Action<ExecSpec?>?): ExecResult {
         return execOperations.exec(closure)
     }
-
 }
 
 internal open class LegacyProjectApiHelper(private val project: Project) : ProjectApiHelper() {

--- a/src/main/kotlin/com/github/gradle/node/util/Provider.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/Provider.kt
@@ -3,12 +3,12 @@ package com.github.gradle.node.util
 import org.gradle.api.provider.Provider
 
 internal fun <A, B> zip(aProvider: Provider<A>, bProvider: Provider<B>): Provider<Pair<A, B>> {
-    return aProvider.flatMap { a -> bProvider.map { b -> Pair(a, b) } }
+    return aProvider.flatMap { a -> bProvider.map { b -> Pair(a!!, b!!) } }
 }
 
 internal fun <A, B, C> zip(aProvider: Provider<A>, bProvider: Provider<B>, cProvider: Provider<C>):
         Provider<Triple<A, B, C>> {
-    return zip(aProvider, bProvider).flatMap { pair -> cProvider.map { c -> Triple(pair.first, pair.second, c) } }
+    return zip(aProvider, bProvider).flatMap { pair -> cProvider.map { c -> Triple(pair.first, pair.second, c!!) } }
 }
 
 internal fun <A, B, C, D> zip(aProvider: Provider<A>, bProvider: Provider<B>, cProvider: Provider<C>,

--- a/src/main/kotlin/com/github/gradle/node/variant/VariantComputer.kt
+++ b/src/main/kotlin/com/github/gradle/node/variant/VariantComputer.kt
@@ -96,7 +96,7 @@ internal class VariantComputer @JvmOverloads constructor(
     private fun computeProductBinDir(productDirProvider: Provider<Directory>) =
             if (platformHelper.isWindows) productDirProvider else productDirProvider.map { it.dir("bin") }
 
-    fun computeArchiveDependency(nodeExtension: NodeExtension): Provider<String> {
+    fun computeNodeArchiveDependency(nodeExtension: NodeExtension): Provider<String> {
         val osName = platformHelper.osName
         val osArch = platformHelper.osArch
         val type = if (platformHelper.isWindows) "zip" else "tar.gz"

--- a/src/main/kotlin/com/github/gradle/node/yarn/task/YarnInstallTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/task/YarnInstallTask.kt
@@ -18,8 +18,7 @@ import java.io.File
 abstract class YarnInstallTask : YarnTask() {
 
     @get:Internal
-    val nodeModulesOutputFilter =
-            project.objects.property<Action<ConfigurableFileTree>>()
+    val nodeModulesOutputFilter = objects.property<Action<ConfigurableFileTree>>()
 
     init {
         group = NodePlugin.YARN_GROUP
@@ -49,7 +48,7 @@ abstract class YarnInstallTask : YarnTask() {
 
     private fun projectFileIfExists(name: String): Provider<File> {
         return nodeExtension.nodeProjectDir.map { it.file(name).asFile }
-                .flatMap { if (it.exists()) project.providers.provider { it } else project.providers.provider { null } }
+                .flatMap { if (it.exists()) providers.provider { it } else providers.provider { null } }
     }
 
     @Optional
@@ -58,7 +57,7 @@ abstract class YarnInstallTask : YarnTask() {
     protected fun getNodeModulesDirectory(): Provider<Directory> {
         val filter = nodeModulesOutputFilter.orNull
         return if (filter == null) nodeExtension.nodeProjectDir.dir("node_modules")
-        else project.providers.provider { null }
+        else providers.provider { null }
     }
 
     @Optional
@@ -69,10 +68,10 @@ abstract class YarnInstallTask : YarnTask() {
         return zip(nodeModulesDirectoryProvider, nodeModulesOutputFilter)
                 .flatMap { (nodeModulesDirectory, nodeModulesOutputFilter) ->
                     if (nodeModulesOutputFilter != null) {
-                        val fileTree = project.fileTree(nodeModulesDirectory)
+                        val fileTree = projectHelper.fileTree(nodeModulesDirectory)
                         nodeModulesOutputFilter.execute(fileTree)
-                        project.providers.provider { fileTree }
-                    } else project.providers.provider { null }
+                        providers.provider { fileTree }
+                    } else providers.provider { null }
                 }
     }
 

--- a/src/main/kotlin/com/github/gradle/node/yarn/task/YarnInstallTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/task/YarnInstallTask.kt
@@ -1,6 +1,5 @@
 package com.github.gradle.node.yarn.task
 
-import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.util.zip
 import org.gradle.api.Action
@@ -16,8 +15,7 @@ import java.io.File
 /**
  * yarn install that only gets executed if gradle decides so.
  */
-open class YarnInstallTask : YarnTask() {
-    private val nodeExtension by lazy { NodeExtension[project] }
+abstract class YarnInstallTask : YarnTask() {
 
     @get:Internal
     val nodeModulesOutputFilter =

--- a/src/main/kotlin/com/github/gradle/node/yarn/task/YarnSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/task/YarnSetupTask.kt
@@ -11,7 +11,7 @@ import java.io.File
 /**
  * Setup a specific version of Yarn to be used by the build.
  */
-open class YarnSetupTask : NpmSetupTask() {
+abstract class YarnSetupTask : NpmSetupTask() {
     init {
         group = NodePlugin.YARN_GROUP
         description = "Setup a specific version of Yarn to be used by the build."

--- a/src/main/kotlin/com/github/gradle/node/yarn/task/YarnTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/task/YarnTask.kt
@@ -1,10 +1,14 @@
 package com.github.gradle.node.yarn.task
 
+import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.exec.NodeExecConfiguration
+import com.github.gradle.node.util.ProjectApiHelper
 import com.github.gradle.node.yarn.exec.YarnExecRunner
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -13,27 +17,41 @@ import org.gradle.kotlin.dsl.listProperty
 import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 import org.gradle.process.ExecSpec
+import javax.inject.Inject
 
-open class YarnTask : DefaultTask() {
+abstract class YarnTask : DefaultTask() {
+
+    @get:Inject
+    abstract val objects: ObjectFactory
+
+    @get:Inject
+    abstract val providers: ProviderFactory
+
     @get:Optional
     @get:Input
-    val yarnCommand = project.objects.listProperty<String>()
+    val yarnCommand = objects.listProperty<String>()
 
     @get:Optional
     @get:Input
-    val args = project.objects.listProperty<String>()
+    val args = objects.listProperty<String>()
 
     @get:Input
-    val ignoreExitValue = project.objects.property<Boolean>().convention(false)
+    val ignoreExitValue = objects.property<Boolean>().convention(false)
 
     @get:Internal
-    val workingDir = project.objects.directoryProperty()
+    val workingDir = objects.directoryProperty()
 
     @get:Input
-    val environment = project.objects.mapProperty<String, String>()
+    val environment = objects.mapProperty<String, String>()
 
     @get:Internal
-    val execOverrides = project.objects.property<Action<ExecSpec>>()
+    val execOverrides = objects.property<Action<ExecSpec>>()
+
+    @get:Internal
+    val projectHelper = ProjectApiHelper.newInstance(project)
+
+    @get:Internal
+    val nodeExtension = NodeExtension[project]
 
     init {
         group = NodePlugin.NODE_GROUP
@@ -52,7 +70,7 @@ open class YarnTask : DefaultTask() {
         val nodeExecConfiguration =
                 NodeExecConfiguration(command, environment.get(), workingDir.asFile.orNull,
                         ignoreExitValue.get(), execOverrides.orNull)
-        val yarnExecRunner = YarnExecRunner()
-        yarnExecRunner.executeYarnCommand(project, nodeExecConfiguration)
+        val yarnExecRunner = objects.newInstance(YarnExecRunner::class.java)
+        yarnExecRunner.executeYarnCommand(projectHelper, nodeExtension, nodeExecConfiguration)
     }
 }

--- a/src/test/groovy/com/github/gradle/AbstractIntegTest.groovy
+++ b/src/test/groovy/com/github/gradle/AbstractIntegTest.groovy
@@ -26,9 +26,13 @@ abstract class AbstractIntegTest extends Specification {
     }
 
     protected final GradleRunner newRunner(final String... args) {
+        List<String> additionalArgs = ["--warning-mode=fail"]
+        if (isConfigurationCacheEnabled()) {
+            additionalArgs.add("--configuration-cache")
+        }
         return GradleRunner.create()
                 .withProjectDir(projectDir)
-                .withArguments([*args, "--warning-mode=fail"])
+                .withArguments([*args, *additionalArgs])
                 .withPluginClasspath()
                 .forwardOutput()
                 .withGradleVersion(gradleVersion.version)
@@ -117,5 +121,9 @@ abstract class AbstractIntegTest extends Specification {
     protected boolean environmentDumpContainsPathVariable(environmentDump) {
         // Sometimes the PATH variable is not defined in Windows Powershell, but the PATHEXT is
         return Pattern.compile("^PATH(?:EXT)?=.+\$", Pattern.MULTILINE).matcher(environmentDump).find()
+    }
+
+    protected isConfigurationCacheEnabled() {
+        return gradleVersion >= GradleVersion.version("6.6")
     }
 }

--- a/src/test/groovy/com/github/gradle/AbstractIntegTest.groovy
+++ b/src/test/groovy/com/github/gradle/AbstractIntegTest.groovy
@@ -26,9 +26,13 @@ abstract class AbstractIntegTest extends Specification {
     }
 
     protected final GradleRunner newRunner(final String... args) {
+        List<String> allArgs = []
+        allArgs.addAll(args)
+        allArgs.addAll(["--warning-mode=fail"])
+        println(allArgs)
         return GradleRunner.create()
                 .withProjectDir(projectDir)
-                .withArguments(args)
+                .withArguments(allArgs)
                 .withPluginClasspath()
                 .forwardOutput()
                 .withGradleVersion(gradleVersion.version)

--- a/src/test/groovy/com/github/gradle/AbstractIntegTest.groovy
+++ b/src/test/groovy/com/github/gradle/AbstractIntegTest.groovy
@@ -26,13 +26,9 @@ abstract class AbstractIntegTest extends Specification {
     }
 
     protected final GradleRunner newRunner(final String... args) {
-        List<String> allArgs = []
-        allArgs.addAll(args)
-        allArgs.addAll(["--warning-mode=fail"])
-        println(allArgs)
         return GradleRunner.create()
                 .withProjectDir(projectDir)
-                .withArguments(allArgs)
+                .withArguments([*args, "--warning-mode=fail"])
                 .withPluginClasspath()
                 .forwardOutput()
                 .withGradleVersion(gradleVersion.version)

--- a/src/test/groovy/com/github/gradle/AbstractProjectTest.groovy
+++ b/src/test/groovy/com/github/gradle/AbstractProjectTest.groovy
@@ -14,8 +14,8 @@ class AbstractProjectTest extends Specification {
 
     def setup() {
         this.projectDir = this.temporaryFolder.root
-        this.project = (ProjectInternal) ProjectBuilder.builder().
-                withProjectDir(this.projectDir).
-                build()
+        this.project = (ProjectInternal) ProjectBuilder.builder()
+                .withProjectDir(this.projectDir)
+                .build()
     }
 }

--- a/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
@@ -47,8 +47,8 @@ class KotlinDsl_integTest extends AbstractIntegTest {
         outputFile.exists()
         def zipFile = new ZipFile(outputFile)
         def zipFileEntries = Collections.list(zipFile.entries())
-        zipFileEntries.findAll { it.name.equals("index.js") }.size() == 3
-        zipFileEntries.findAll { it.name.equals("main.js") }.size() == 3
-        zipFileEntries.size() == 6
+        zipFileEntries.findAll { it.name.endsWith("/index.js") }.size() == 3
+        zipFileEntries.findAll { it.name.endsWith("/main.js") }.size() == 3
+        zipFileEntries.size() == 9
     }
 }

--- a/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
@@ -17,7 +17,7 @@ class KotlinDsl_integTest extends AbstractIntegTest {
         copyResources("fixtures/javascript-project/")
 
         when:
-        def result1 = build("run")
+        def result1 = build("run", "--configuration-cache")
 
         then:
         result1.task(":nodeSetup").outcome == TaskOutcome.SKIPPED
@@ -33,7 +33,7 @@ class KotlinDsl_integTest extends AbstractIntegTest {
         result1.output.split("1 passing").length == 4
 
         when:
-        def result2 = build("package")
+        def result2 = build("package", "--configuration-cache")
 
         then:
         result2.task(":nodeSetup").outcome == TaskOutcome.SKIPPED

--- a/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
@@ -1,9 +1,7 @@
 package com.github.gradle.node
 
 import com.github.gradle.AbstractIntegTest
-import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
-import org.gradle.util.GradleVersion
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 
@@ -19,7 +17,7 @@ class KotlinDsl_integTest extends AbstractIntegTest {
         copyResources("fixtures/javascript-project/")
 
         when:
-        def result1 = buildWithConfigurationCacheIfAvailable("run")
+        def result1 = build("run")
 
         then:
         result1.task(":nodeSetup").outcome == TaskOutcome.SKIPPED
@@ -35,7 +33,7 @@ class KotlinDsl_integTest extends AbstractIntegTest {
         result1.output.split("1 passing").length == 4
 
         when:
-        def result2 = buildWithConfigurationCacheIfAvailable("package")
+        def result2 = build("package")
 
         then:
         result2.task(":nodeSetup").outcome == TaskOutcome.SKIPPED
@@ -52,12 +50,5 @@ class KotlinDsl_integTest extends AbstractIntegTest {
         zipFileEntries.findAll { it.name.endsWith("/index.js") }.size() == 3
         zipFileEntries.findAll { it.name.endsWith("/main.js") }.size() == 3
         zipFileEntries.size() == 9
-    }
-
-    private BuildResult buildWithConfigurationCacheIfAvailable(String... args) {
-        if (gradleVersion >= GradleVersion.version("6.6")) {
-            return build(*[*args, "--configuration-cache"])
-        }
-        return build(args)
     }
 }

--- a/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
@@ -1,7 +1,9 @@
 package com.github.gradle.node
 
 import com.github.gradle.AbstractIntegTest
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
 import org.junit.Rule
 import org.junit.contrib.java.lang.system.EnvironmentVariables
 
@@ -17,7 +19,7 @@ class KotlinDsl_integTest extends AbstractIntegTest {
         copyResources("fixtures/javascript-project/")
 
         when:
-        def result1 = build("run", "--configuration-cache")
+        def result1 = buildWithConfigurationCacheIfAvailable("run")
 
         then:
         result1.task(":nodeSetup").outcome == TaskOutcome.SKIPPED
@@ -33,7 +35,7 @@ class KotlinDsl_integTest extends AbstractIntegTest {
         result1.output.split("1 passing").length == 4
 
         when:
-        def result2 = build("package", "--configuration-cache")
+        def result2 = buildWithConfigurationCacheIfAvailable("package")
 
         then:
         result2.task(":nodeSetup").outcome == TaskOutcome.SKIPPED
@@ -50,5 +52,12 @@ class KotlinDsl_integTest extends AbstractIntegTest {
         zipFileEntries.findAll { it.name.endsWith("/index.js") }.size() == 3
         zipFileEntries.findAll { it.name.endsWith("/main.js") }.size() == 3
         zipFileEntries.size() == 9
+    }
+
+    private BuildResult buildWithConfigurationCacheIfAvailable(String... args) {
+        if (gradleVersion >= GradleVersion.version("6.8")) {
+            return build(*[*args, "--configuration-cache"])
+        }
+        return build(args)
     }
 }

--- a/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/KotlinDsl_integTest.groovy
@@ -55,7 +55,7 @@ class KotlinDsl_integTest extends AbstractIntegTest {
     }
 
     private BuildResult buildWithConfigurationCacheIfAvailable(String... args) {
-        if (gradleVersion >= GradleVersion.version("6.8")) {
+        if (gradleVersion >= GradleVersion.version("6.6")) {
             return build(*[*args, "--configuration-cache"])
         }
         return build(args)

--- a/src/test/groovy/com/github/gradle/node/NodePluginTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/NodePluginTest.groovy
@@ -1,16 +1,8 @@
 package com.github.gradle.node
 
 import com.github.gradle.AbstractProjectTest
-import com.github.gradle.node.util.PlatformHelper
 
 class NodePluginTest extends AbstractProjectTest {
-    private Properties props
-
-    def setup() {
-        props = new Properties()
-        PlatformHelper.INSTANCE = new PlatformHelper(props)
-    }
-
     def 'check default tasks'() {
         when:
         project.apply plugin: 'com.github.node-gradle.node'

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmInstallTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmInstallTaskTest.groovy
@@ -2,7 +2,6 @@ package com.github.gradle.node.npm.task
 
 import com.github.gradle.node.npm.proxy.GradleProxyHelper
 import com.github.gradle.node.task.AbstractTaskTest
-import org.gradle.process.ExecSpec
 
 class NpmInstallTaskTest extends AbstractTaskTest {
     def cleanup() {
@@ -12,11 +11,11 @@ class NpmInstallTaskTest extends AbstractTaskTest {
     def "exec npm install task with configured proxy"() {
         given:
         props.setProperty('os.name', 'Linux')
-        execSpec = Mock(ExecSpec)
         GradleProxyHelper.setHttpsProxyHost("my-super-proxy.net")
         GradleProxyHelper.setHttpsProxyPort(11235)
 
         def task = project.tasks.getByName("npmInstall")
+        mockProjectApiHelperExec(task)
 
         when:
         project.evaluate()
@@ -31,12 +30,12 @@ class NpmInstallTaskTest extends AbstractTaskTest {
     def "exec npm install task with configured proxy but disabled"() {
         given:
         props.setProperty('os.name', 'Linux')
-        execSpec = Mock(ExecSpec)
         GradleProxyHelper.setHttpsProxyHost("my-super-proxy.net")
         GradleProxyHelper.setHttpsProxyPort(11235)
         nodeExtension.useGradleProxySettings.set(false)
 
         def task = project.tasks.getByName("npmInstall")
+        mockProjectApiHelperExec(task)
 
         when:
         project.evaluate()

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
@@ -142,10 +142,10 @@ class NpmInstall_integTest extends AbstractIntegTest {
 
             task verifyIO {
                 doLast {
-                    if (!tasks.named("npmInstall").get().outputs.files.contains(project.file('package-lock.json'))) {
+                    if (!tasks.named("npmInstall").get().outputs.files.contains(file('package-lock.json'))) {
                         throw new RuntimeException("package-lock.json is not in INSTALL'S outputs!")
                     }
-                    if (tasks.named("npmInstall").get().inputs.files.contains(project.file('package-lock.json'))) {
+                    if (tasks.named("npmInstall").get().inputs.files.contains(file('package-lock.json'))) {
                         throw new RuntimeException("package-lock.json is in INSTALL'S inputs!")
                     }
                 }
@@ -174,10 +174,10 @@ class NpmInstall_integTest extends AbstractIntegTest {
 
             task verifyIO {
                 doLast {
-                    if (tasks.named("npmInstall").get().outputs.files.contains(project.file('package-lock.json'))) {
+                    if (tasks.named("npmInstall").get().outputs.files.contains(file('package-lock.json'))) {
                         throw new RuntimeException("package-lock.json is in CI'S outputs!")
                     }
-                    if (!tasks.named("npmInstall").get().inputs.files.contains(project.file('package-lock.json'))) {
+                    if (!tasks.named("npmInstall").get().inputs.files.contains(file('package-lock.json'))) {
                         throw new RuntimeException("package-lock.json is not in CI'S inputs!")
                     }
                 }

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
@@ -193,7 +193,7 @@ class NpmInstall_integTest extends AbstractIntegTest {
         result.outcome == TaskOutcome.SUCCESS
     }
 
-    def 'verity output configuration'() {
+    def 'verify output configuration'() {
         given:
         writeBuild('''
             plugins {
@@ -252,7 +252,7 @@ class NpmInstall_integTest extends AbstractIntegTest {
         createFile("node_modules/mocha/package.json").exists()
     }
 
-    def 'verity output configuration when filtering node_modules output'() {
+    def 'verify output configuration when filtering node_modules output'() {
         given:
         writeBuild('''
             plugins {

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmSetupTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmSetupTaskTest.groovy
@@ -12,7 +12,6 @@ class NpmSetupTaskTest extends AbstractTaskTest {
     def "disable npmSetup task when no npm version is specified"() {
         given:
         props.setProperty('os.name', 'Linux')
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', NpmSetupTask)
 
@@ -27,9 +26,9 @@ class NpmSetupTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.npmVersion.set('6.4.1')
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', NpmSetupTask)
+        mockProjectApiHelperExec(task)
 
         when:
         project.evaluate()
@@ -48,11 +47,11 @@ class NpmSetupTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.npmVersion.set('6.4.1')
-        execSpec = Mock(ExecSpec)
         GradleProxyHelper.setHttpProxyHost("my-proxy.net")
         GradleProxyHelper.setHttpProxyPort(1234)
 
         def task = project.tasks.create('simple', NpmSetupTask)
+        mockProjectApiHelperExec(task)
 
         when:
         project.evaluate()

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmTaskTest.groovy
@@ -1,9 +1,7 @@
 package com.github.gradle.node.npm.task
 
-
 import com.github.gradle.node.npm.proxy.GradleProxyHelper
 import com.github.gradle.node.task.AbstractTaskTest
-import org.gradle.process.ExecSpec
 
 import static com.github.gradle.node.NodeExtension.DEFAULT_NODE_VERSION
 
@@ -15,9 +13,9 @@ class NpmTaskTest extends AbstractTaskTest {
     def "exec npm task"() {
         given:
         props.setProperty('os.name', 'Linux')
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', NpmTask)
+        mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
         task.environment.set(['a': '1'])
         task.ignoreExitValue.set(true)
@@ -37,9 +35,9 @@ class NpmTaskTest extends AbstractTaskTest {
     def "exec npm task (windows)"() {
         given:
         props.setProperty('os.name', 'Windows')
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', NpmTask)
+        mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
         task.environment.set(['a': '1'])
         task.ignoreExitValue.set(true)
@@ -60,11 +58,11 @@ class NpmTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.download.set(true)
-        execSpec = Mock(ExecSpec)
         def nodeDir = projectDir.toPath().resolve(".gradle").resolve("nodejs")
                 .resolve("node-v${DEFAULT_NODE_VERSION}-linux-x64")
 
         def task = project.tasks.create('simple', NpmTask)
+        mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 
         when:
@@ -89,13 +87,13 @@ class NpmTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.download.set(true)
-        execSpec = Mock(ExecSpec)
         def nodeDir = projectDir.toPath().resolve(".gradle").resolve("nodejs")
                 .resolve("node-v${DEFAULT_NODE_VERSION}-linux-x64")
         GradleProxyHelper.setHttpProxyHost("host")
         GradleProxyHelper.setHttpProxyPort(123)
 
         def task = project.tasks.create('simple', NpmTask)
+        mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 
         when:
@@ -120,11 +118,11 @@ class NpmTaskTest extends AbstractTaskTest {
     def "exec npm task with configured proxy"() {
         given:
         props.setProperty('os.name', 'Linux')
-        execSpec = Mock(ExecSpec)
         GradleProxyHelper.setHttpsProxyHost("my-super-proxy.net")
         GradleProxyHelper.setHttpsProxyPort(11235)
 
         def task = project.tasks.create('simple', NpmTask)
+        mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
 
         when:
@@ -140,12 +138,12 @@ class NpmTaskTest extends AbstractTaskTest {
     def "exec npm task with configured proxy but disabled"() {
         given:
         props.setProperty('os.name', 'Linux')
-        execSpec = Mock(ExecSpec)
         GradleProxyHelper.setHttpsProxyHost("my-super-proxy.net")
         GradleProxyHelper.setHttpsProxyPort(11235)
         nodeExtension.useGradleProxySettings.set(false)
 
         def task = project.tasks.create('simple', NpmTask)
+        mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
 
         when:

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmTask_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmTask_integTest.groovy
@@ -85,7 +85,7 @@ class NpmTask_integTest extends AbstractIntegTest {
         result3.task(":nodeSetup").outcome == TaskOutcome.UP_TO_DATE
         result3.task(":npmSetup").outcome == TaskOutcome.SKIPPED
         result3.task(":npmInstall").outcome == TaskOutcome.UP_TO_DATE
-        result3.task(":env").outcome == TaskOutcome.UP_TO_DATE
+        result3.task(":env").outcome == (isConfigurationCacheEnabled() ? TaskOutcome.SUCCESS : TaskOutcome.UP_TO_DATE)
 
         when:
         def result4 = build(":env", "-DignoreExitValue=true", "-DnotExistingCommand=true")

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpxTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpxTaskTest.groovy
@@ -2,15 +2,14 @@ package com.github.gradle.node.npm.task
 
 import com.github.gradle.node.task.AbstractTaskTest
 import com.github.gradle.node.variant.VariantComputer
-import org.gradle.process.ExecSpec
 
 class NpxTaskTest extends AbstractTaskTest {
     def "exec npx task"() {
         given:
         props.setProperty('os.name', 'Linux')
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', NpxTask)
+        mockProjectApiHelperExec(task)
         task.command.set('command')
         task.args.set(['a', 'b'])
         task.environment.set(['a': '1'])
@@ -34,9 +33,9 @@ class NpxTaskTest extends AbstractTaskTest {
     def "exec npx task (windows)"() {
         given:
         props.setProperty('os.name', 'Windows')
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', NpxTask)
+        mockProjectApiHelperExec(task)
         task.command.set('command')
         task.args.set(['a', 'b'])
         task.environment.set(['a': '1'])
@@ -61,13 +60,13 @@ class NpxTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.download.set(true)
-        execSpec = Mock(ExecSpec)
         def variantComputer = new VariantComputer()
         def nodeDir = variantComputer.computeNodeDir(nodeExtension)
         def nodeBinDir = variantComputer.computeNodeBinDir(nodeDir)
         def npxScriptFile = variantComputer.computeNpmScriptFile(nodeDir, "npx")
 
         def task = project.tasks.create('simple', NpxTask)
+        mockProjectApiHelperExec(task)
 
         when:
         project.evaluate()

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpxTask_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpxTask_integTest.groovy
@@ -113,7 +113,7 @@ class NpxTask_integTest extends AbstractIntegTest {
         result3.task(":nodeSetup").outcome == TaskOutcome.UP_TO_DATE
         result3.task(":npmSetup").outcome == TaskOutcome.SKIPPED
         result3.task(":npmInstall").outcome == TaskOutcome.UP_TO_DATE
-        result3.task(":env").outcome == TaskOutcome.UP_TO_DATE
+        result3.task(":env").outcome == (isConfigurationCacheEnabled() ? TaskOutcome.SUCCESS : TaskOutcome.UP_TO_DATE)
 
         when:
         def result4 = build(":env", "-DignoreExitValue=true", "-DnotExistingCommand=true")

--- a/src/test/groovy/com/github/gradle/node/task/AbstractTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/task/AbstractTaskTest.groovy
@@ -16,9 +16,11 @@ abstract class AbstractTaskTest extends AbstractProjectTest {
     ExecSpec execSpec
     Properties props
     NodeExtension nodeExtension
+    PlatformHelper originalPlatformHelper
 
     def setup() {
         props = new Properties()
+        originalPlatformHelper = PlatformHelper.INSTANCE
         PlatformHelper.INSTANCE = new PlatformHelper(props)
 
         execSpec = Mock(ExecSpec)
@@ -26,6 +28,10 @@ abstract class AbstractTaskTest extends AbstractProjectTest {
 
         project.apply plugin: 'com.github.node-gradle.node'
         nodeExtension = NodeExtension.get(project)
+    }
+
+    def cleanup() {
+        PlatformHelper.INSTANCE = originalPlatformHelper
     }
 
     protected mockProjectApiHelperExec(Task task, String fieldName = "projectHelper") {

--- a/src/test/groovy/com/github/gradle/node/task/AbstractTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/task/AbstractTaskTest.groovy
@@ -3,8 +3,9 @@ package com.github.gradle.node.task
 import com.github.gradle.AbstractProjectTest
 import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.util.PlatformHelper
+import com.github.gradle.node.util.ProjectApiHelper
 import org.gradle.api.Action
-import org.gradle.api.internal.ProcessOperations
+import org.gradle.api.Task
 import org.gradle.process.ExecResult
 import org.gradle.process.ExecSpec
 
@@ -20,40 +21,47 @@ abstract class AbstractTaskTest extends AbstractProjectTest {
         props = new Properties()
         PlatformHelper.INSTANCE = new PlatformHelper(props)
 
+        execSpec = Mock(ExecSpec)
         execResult = Mock(ExecResult)
 
         project.apply plugin: 'com.github.node-gradle.node'
         nodeExtension = NodeExtension.get(project)
-
-        mockExec()
     }
 
-    private void mockExec() {
-        // Create mock to track exec calls
-        ProcessOperations processOperations = Spy(project.getProcessOperations())
-        processOperations.exec(_ as Action<ExecSpec>) >> { Action<ExecSpec> action ->
+    protected mockProjectApiHelperExec(Task task, String fieldName = "projectHelper") {
+        Field projectApiHelperField = findProjectApiHelperTaskField(task, fieldName)
+        projectApiHelperField.setAccessible(true)
+        ProjectApiHelper projectApiHelper = Spy(projectApiHelperField.get(task)) as ProjectApiHelper
+        projectApiHelper.exec(_ as Action<ExecSpec>) >> { Action<ExecSpec> action ->
             action.execute(execSpec)
             return execResult
         }
-        // Gradle does not allow us to easily inject our own services; manually override the ProcessOperations service
-        Field processOperationsField = project.getClass().getDeclaredFields()
-                .findAll { it.name ==~ /\w+processOperations\w+/ }
-                .tap { assert it.size() == 1 }
-                .first()
-        processOperationsField.setAccessible(true)
-        processOperationsField.set(project, processOperations)
+        projectApiHelperField.set(task, projectApiHelper)
+        projectApiHelperField.setAccessible(false)
     }
 
-    protected containsPath(final Map<String, ?> env) {
+    private static Field findProjectApiHelperTaskField(Task task, String fieldName) {
+        Class<?> type = task.getClass()
+        while (type != null) {
+            try {
+                return type.getDeclaredField(fieldName)
+            } catch (NoSuchFieldException _) {
+                type = type.getSuperclass()
+            }
+        }
+        throw new IllegalStateException("No ${fieldName} field found in class ${task.getClass()}")
+    }
+
+    protected static containsPath(final Map<String, ?> env) {
         return env['PATH'] != null || env['Path'] != null
     }
 
     // Workaround a strange issue on Github actions macOS and Windows hosts
-    protected List<String> fixAbsolutePaths(Iterable<String> path) {
+    protected static List<String> fixAbsolutePaths(Iterable<String> path) {
         return path.collect { fixAbsolutePath(it) }
     }
 
-    protected fixAbsolutePath(String path) {
+    protected static fixAbsolutePath(String path) {
         return path.replace('/private/', '/')
                 .replace('C:\\Users\\runneradmin\\', 'C:\\Users\\RUNNER~1\\')
     }

--- a/src/test/groovy/com/github/gradle/node/task/NodeTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/task/NodeTaskTest.groovy
@@ -1,7 +1,5 @@
 package com.github.gradle.node.task
 
-import org.gradle.process.ExecSpec
-
 class NodeTaskTest extends AbstractTaskTest {
     def "script not set"() {
         given:
@@ -18,10 +16,10 @@ class NodeTaskTest extends AbstractTaskTest {
     def "exec node task"() {
         given:
         props.setProperty('os.name', 'Linux')
-        execSpec = Mock(ExecSpec)
         nodeExtension.download.set(false)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
         task.options.set(['c', 'd'])
         task.environment.set(['a': '1'])
@@ -47,10 +45,10 @@ class NodeTaskTest extends AbstractTaskTest {
     def "execOverrides test"() {
         given:
         props.setProperty('os.name', 'Linux')
-        execSpec = Mock(ExecSpec)
         nodeExtension.download.set(false)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockProjectApiHelperExec(task)
         task.ignoreExitValue.set(true)
 
         def script = new File(projectDir, 'script.js')
@@ -73,9 +71,9 @@ class NodeTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.download.set(true)
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockProjectApiHelperExec(task)
         def script = new File(projectDir, 'script.js')
         task.script.set(script)
 
@@ -93,9 +91,9 @@ class NodeTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Windows')
         nodeExtension.download.set(false)
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockProjectApiHelperExec(task)
         def script = new File(projectDir, 'script.js')
 
         task.args.set(['a', 'b'])
@@ -117,9 +115,9 @@ class NodeTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Windows')
         nodeExtension.download.set(true)
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockProjectApiHelperExec(task)
         def script = new File(projectDir, 'script.js')
         task.script.set(script)
 

--- a/src/test/groovy/com/github/gradle/node/task/NodeTask_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/task/NodeTask_integTest.groovy
@@ -236,7 +236,6 @@ class NodeTask_integTest extends AbstractIntegTest {
         def result = buildAndFail("nodeSetup")
 
         then:
-        result.task(":nodeSetup").outcome == TaskOutcome.FAILED
         result.output.contains("Cannot resolve external dependency org.nodejs:node:${DEFAULT_NODE_VERSION} because no repositories are defined.")
     }
 }

--- a/src/test/groovy/com/github/gradle/node/task/NodeTask_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/task/NodeTask_integTest.groovy
@@ -143,7 +143,7 @@ class NodeTask_integTest extends AbstractIntegTest {
 
         then:
         result7.task(":nodeSetup").outcome == TaskOutcome.UP_TO_DATE
-        result7.task(":env").outcome == TaskOutcome.UP_TO_DATE
+        result7.task(":env").outcome == (isConfigurationCacheEnabled() ? TaskOutcome.SUCCESS : TaskOutcome.UP_TO_DATE)
 
         when:
         // Reset build arguments to ensure the next change is not up-to-date

--- a/src/test/groovy/com/github/gradle/node/variant/VariantComputerTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/variant/VariantComputerTest.groovy
@@ -41,7 +41,7 @@ class VariantComputerTest extends Specification {
         def variantComputer = new VariantComputer()
 
         when:
-        def computedArchiveDependency = variantComputer.computeArchiveDependency(nodeExtension)
+        def computedArchiveDependency = variantComputer.computeNodeArchiveDependency(nodeExtension)
         def computedNodeDir = variantComputer.computeNodeDir(nodeExtension)
         def computedNodeBinDir = variantComputer.computeNodeBinDir(computedNodeDir)
         def computedNodeExec = variantComputer.computeNodeExec(nodeExtension, computedNodeBinDir)
@@ -82,7 +82,7 @@ class VariantComputerTest extends Specification {
         def variantComputer = new VariantComputer()
 
         when:
-        def computedArchiveDependency = variantComputer.computeArchiveDependency(nodeExtension)
+        def computedArchiveDependency = variantComputer.computeNodeArchiveDependency(nodeExtension)
         def computedNodeDir = variantComputer.computeNodeDir(nodeExtension)
         def computedNodeBinDir = variantComputer.computeNodeBinDir(computedNodeDir)
         def computedNodeExec = variantComputer.computeNodeExec(nodeExtension, computedNodeBinDir)
@@ -127,7 +127,7 @@ class VariantComputerTest extends Specification {
         def variantComputer = new VariantComputer(platformHelperSpy)
 
         when:
-        def computedArchiveDependency = variantComputer.computeArchiveDependency(nodeExtension)
+        def computedArchiveDependency = variantComputer.computeNodeArchiveDependency(nodeExtension)
         def computedNodeDir = variantComputer.computeNodeDir(nodeExtension)
         def computedNodeBinDir = variantComputer.computeNodeBinDir(computedNodeDir)
         def computedNodeExec = variantComputer.computeNodeExec(nodeExtension, computedNodeBinDir)

--- a/src/test/groovy/com/github/gradle/node/yarn/task/YarnSetupTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/yarn/task/YarnSetupTaskTest.groovy
@@ -2,7 +2,6 @@ package com.github.gradle.node.yarn.task
 
 import com.github.gradle.node.npm.proxy.GradleProxyHelper
 import com.github.gradle.node.task.AbstractTaskTest
-import org.gradle.process.ExecSpec
 
 class YarnSetupTaskTest extends AbstractTaskTest {
     def cleanup() {
@@ -11,11 +10,11 @@ class YarnSetupTaskTest extends AbstractTaskTest {
 
     def "exec yarnSetup task without any yarn version specified and proxy configured"() {
         given:
-        execSpec = Mock(ExecSpec)
         GradleProxyHelper.setHttpProxyHost("my-proxy")
         GradleProxyHelper.setHttpProxyPort(80)
 
         def task = project.tasks.create('simple', YarnSetupTask)
+        mockProjectApiHelperExec(task)
 
         when:
         project.evaluate()
@@ -33,12 +32,12 @@ class YarnSetupTaskTest extends AbstractTaskTest {
 
     def "exec yarnSetup task without any yarn version specified and proxy configured but disabled"() {
         given:
-        execSpec = Mock(ExecSpec)
         GradleProxyHelper.setHttpProxyHost("my-proxy")
         GradleProxyHelper.setHttpProxyPort(80)
         nodeExtension.useGradleProxySettings.set(false)
 
         def task = project.tasks.create('simple', YarnSetupTask)
+        mockProjectApiHelperExec(task)
 
         when:
         project.evaluate()
@@ -56,9 +55,9 @@ class YarnSetupTaskTest extends AbstractTaskTest {
     def "exec yarnSetup task with yarn version specified"() {
         given:
         nodeExtension.yarnVersion.set('1.22.4')
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', YarnSetupTask)
+        mockProjectApiHelperExec(task)
 
         when:
         project.evaluate()

--- a/src/test/groovy/com/github/gradle/node/yarn/task/YarnTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/yarn/task/YarnTaskTest.groovy
@@ -11,9 +11,8 @@ class YarnTaskTest extends AbstractTaskTest {
 
     def "exec yarn task"() {
         given:
-        execSpec = Mock(ExecSpec)
-
         def task = project.tasks.create('simple', YarnTask)
+        mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
         task.environment.set(['a': '1'])
         task.ignoreExitValue.set(true)
@@ -34,9 +33,9 @@ class YarnTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.download.set(true)
-        execSpec = Mock(ExecSpec)
 
         def task = project.tasks.create('simple', YarnTask)
+        mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 
         when:
@@ -56,13 +55,13 @@ class YarnTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.download.set(true)
-        execSpec = Mock(ExecSpec)
         GradleProxyHelper.setHttpsProxyHost("1.2.3.4")
         GradleProxyHelper.setHttpsProxyPort(443)
         GradleProxyHelper.setHttpsProxyUser("me")
         GradleProxyHelper.setHttpsProxyPassword("password")
 
         def task = project.tasks.create('simple', YarnTask)
+        mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 
         when:
@@ -83,7 +82,6 @@ class YarnTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.download.set(true)
-        execSpec = Mock(ExecSpec)
         GradleProxyHelper.setHttpsProxyHost("1.2.3.4")
         GradleProxyHelper.setHttpsProxyPort(443)
         GradleProxyHelper.setHttpsProxyUser("me")
@@ -91,6 +89,7 @@ class YarnTaskTest extends AbstractTaskTest {
         nodeExtension.useGradleProxySettings.set(false)
 
         def task = project.tasks.create('simple', YarnTask)
+        mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 
         when:

--- a/src/test/groovy/com/github/gradle/node/yarn/task/YarnTask_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/yarn/task/YarnTask_integTest.groovy
@@ -87,7 +87,7 @@ class YarnTask_integTest extends AbstractIntegTest {
         result3.task(":nodeSetup").outcome == TaskOutcome.UP_TO_DATE
         result3.task(":yarnSetup").outcome == TaskOutcome.UP_TO_DATE
         result3.task(":yarn").outcome == TaskOutcome.UP_TO_DATE
-        result3.task(":env").outcome == TaskOutcome.UP_TO_DATE
+        result3.task(":env").outcome == (isConfigurationCacheEnabled() ? TaskOutcome.SUCCESS : TaskOutcome.UP_TO_DATE)
 
         when:
         def result4 = build(":env", "-DignoreExitValue=true", "-DnotExistingCommand=true")

--- a/src/test/kotlin/com/github/gradle/node/npm/proxy/GradleProxyHelper.kt
+++ b/src/test/kotlin/com/github/gradle/node/npm/proxy/GradleProxyHelper.kt
@@ -1,4 +1,4 @@
-package com.github.gradle.node.npm.proxy;
+package com.github.gradle.node.npm.proxy
 
 class GradleProxyHelper {
     companion object {

--- a/src/test/resources/fixtures/kotlin/build.gradle.kts
+++ b/src/test/resources/fixtures/kotlin/build.gradle.kts
@@ -140,5 +140,13 @@ val buildTaskUsingYarn = tasks.register<YarnTask>("buildYarn") {
 tasks.register<Zip>("package") {
     archiveFileName.set("app.zip")
     destinationDirectory.set(buildDir)
-    from(buildTaskUsingNpx, buildTaskUsingNpm, buildTaskUsingYarn)
+    from(buildTaskUsingNpx) {
+        into("npx")
+    }
+    from(buildTaskUsingNpm) {
+        into("npm")
+    }
+    from (buildTaskUsingYarn) {
+        into("yarn")
+    }
 }

--- a/src/test/resources/fixtures/node-env/build.gradle
+++ b/src/test/resources/fixtures/node-env/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id "com.github.node-gradle.node"
 }
@@ -14,11 +16,6 @@ def changeWorkingDir = isPropertyEnabled("changeWorkingDir")
 def fail = isPropertyEnabled("fail")
 def ignoreExitValue = isPropertyEnabled("ignoreExitValue")
 def outputFile = isPropertyEnabled("outputFile")
-
-def isPropertyEnabled(name) {
-    def property = System.properties[name]
-    return property == 'true'
-}
 
 task env(type: NodeTask) {
     script = file("env.js")
@@ -56,4 +53,11 @@ if (outputFile) {
 
 task version(type: NodeTask) {
     script = file("version.js")
+}
+
+def isPropertyEnabled(String name) {
+    if (GradleVersion.current() >= GradleVersion.version("6.6")) {
+        return providers.systemProperty(name).forUseAtConfigurationTime().isPresent()
+    }
+    return System.properties[name] != null
 }

--- a/src/test/resources/fixtures/node/build.gradle
+++ b/src/test/resources/fixtures/node/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id "com.github.node-gradle.node"
 }
@@ -8,8 +10,8 @@ node {
     workDir = file("build/node")
 }
 
-def changeScript = System.properties["changeScript"] ? System.properties["changeScript"] == "true" : false
-def changeArgs = System.properties["changeArgs"] ? System.properties["changeArgs"] == "true" : false
+def changeScript = isPropertyEnabled("changeScript")
+def changeArgs = isPropertyEnabled("changeArgs")
 
 task hello(type: NodeTask) {
     script = file("simple.js")
@@ -36,4 +38,11 @@ task executeDirectoryScript(type: NodeTask) {
 
 task version(type: NodeTask) {
     script = file("version.js")
+}
+
+def isPropertyEnabled(String name) {
+    if (GradleVersion.current() >= GradleVersion.version("6.6")) {
+        return providers.systemProperty(name).forUseAtConfigurationTime().isPresent()
+    }
+    return System.properties[name] != null
 }

--- a/src/test/resources/fixtures/node/settings.gradle
+++ b/src/test/resources/fixtures/node/settings.gradle
@@ -1,0 +1,7 @@
+import org.gradle.util.GradleVersion
+
+if (GradleVersion.current() >= GradleVersion.version("6.8")) {
+    dependencyResolutionManagement {
+        repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
+    }
+}

--- a/src/test/resources/fixtures/npm-env/build.gradle
+++ b/src/test/resources/fixtures/npm-env/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id "com.github.node-gradle.node"
 }
@@ -55,7 +57,9 @@ if (isPropertyEnabled("outputFile")) {
     }
 }
 
-def isPropertyEnabled(name) {
-    def property = System.properties[name]
-    return property == "true"
+def isPropertyEnabled(String name) {
+    if (GradleVersion.current() >= GradleVersion.version("6.6")) {
+        return providers.systemProperty(name).forUseAtConfigurationTime().isPresent()
+    }
+    return System.properties[name] != null
 }

--- a/src/test/resources/fixtures/npm/build.gradle
+++ b/src/test/resources/fixtures/npm/build.gradle
@@ -1,8 +1,10 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id 'com.github.node-gradle.node'
 }
 
-def changeInputs = System.properties["changeInputs"] ? System.properties["changeInputs"] == 'true' : false
+def changeInputs = isPropertyEnabled("changeInputs")
 
 node {
     npmVersion = "6.12.0"
@@ -25,4 +27,11 @@ task test(type: NpmTask) {
 task version(type: NpmTask) {
     dependsOn npmInstall
     npmCommand = ["--version"]
+}
+
+def isPropertyEnabled(String name) {
+    if (GradleVersion.current() >= GradleVersion.version("6.6")) {
+        return providers.systemProperty(name).forUseAtConfigurationTime().isPresent()
+    }
+    return System.properties[name] != null
 }

--- a/src/test/resources/fixtures/npx-env/build.gradle
+++ b/src/test/resources/fixtures/npx-env/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id "com.github.node-gradle.node"
 }
@@ -53,7 +55,9 @@ if (isPropertyEnabled("outputFile")) {
     }
 }
 
-def isPropertyEnabled(name) {
-    def property = System.properties[name]
-    return property == "true"
+def isPropertyEnabled(String name) {
+    if (GradleVersion.current() >= GradleVersion.version("6.6")) {
+        return providers.systemProperty(name).forUseAtConfigurationTime().isPresent()
+    }
+    return System.properties[name] != null
 }

--- a/src/test/resources/fixtures/npx/build.gradle
+++ b/src/test/resources/fixtures/npx/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id "com.github.node-gradle.node"
 }
@@ -57,7 +59,9 @@ if (isPropertyEnabled("changeInputs")) {
     test.command = "_mocha"
 }
 
-def isPropertyEnabled(name) {
-    def property = System.properties[name]
-    return property == "true"
+def isPropertyEnabled(String name) {
+    if (GradleVersion.current() >= GradleVersion.version("6.6")) {
+        return providers.systemProperty(name).forUseAtConfigurationTime().isPresent()
+    }
+    return System.properties[name] != null
 }

--- a/src/test/resources/fixtures/yarn-env/build.gradle
+++ b/src/test/resources/fixtures/yarn-env/build.gradle
@@ -1,3 +1,5 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id "com.github.node-gradle.node"
 }
@@ -55,7 +57,9 @@ if (isPropertyEnabled("outputFile")) {
     }
 }
 
-def isPropertyEnabled(name) {
-    def property = System.properties[name]
-    return property == "true"
+def isPropertyEnabled(String name) {
+    if (GradleVersion.current() >= GradleVersion.version("6.6")) {
+        return providers.systemProperty(name).forUseAtConfigurationTime().isPresent()
+    }
+    return System.properties[name] != null
 }

--- a/src/test/resources/fixtures/yarn/build.gradle
+++ b/src/test/resources/fixtures/yarn/build.gradle
@@ -1,8 +1,10 @@
+import org.gradle.util.GradleVersion
+
 plugins {
     id "com.github.node-gradle.node"
 }
 
-def changeInputs = System.properties["changeInputs"] ? System.properties["changeInputs"] == "true" : false
+def changeInputs = isPropertyEnabled("changeInputs")
 
 node {
     yarnVersion = "1.18.0"
@@ -26,4 +28,11 @@ task test(type: YarnTask) {
 task version(type: YarnTask) {
     dependsOn yarn
     yarnCommand = ["--version"]
+}
+
+def isPropertyEnabled(String name) {
+    if (GradleVersion.current() >= GradleVersion.version("6.6")) {
+        return providers.systemProperty(name).forUseAtConfigurationTime().isPresent()
+    }
+    return System.properties[name] != null
 }


### PR DESCRIPTION
With the exception of NodeSetupTask this adds configuration cache support.

It changes many tasks classes to be `abstract` so we can inject the various services (like `ProjectLayout`) which will break backwards compatibility. The alternatives seem to be constructor injection which doesn't look great as it bubbles upwards, or property injection but with a dummy method which I guess is the real alternative.
But with that in mind we might want to include this in 3.x and provide another RC if we get the unit-tests working again.

With that said, as was mentioned in #111 unit tests fails to capture the invocation of execSpec: [NpmInstallTaskTest.groovy#L15](https://github.com/node-gradle/gradle-node-plugin/blob/3.0.0-rc4/src/test/groovy/com/github/gradle/node/npm/task/NpmInstallTaskTest.groovy#L15)

The mock and spy is setup like this: [AbstractTaskTest.groovy#L31-L45](https://github.com/node-gradle/gradle-node-plugin/blob/3.0.0-rc4/src/test/groovy/com/github/gradle/node/task/AbstractTaskTest.groovy#L31-L45) and while this works fine with project I can't get this same pattern to work with `ExecOperations`. 
I tried the same pattern but can't find anything to hook onto, I tried retrieving the `DefaultProjectApiHelper` and changing the `execOperations` through metaprogramming but with no results.

So tests should work with `5.6.4` and `6.0` but fail on `>= 6.6.1`. We're currently using `6.8-rc-1` so that we can make use of `--included-build` and `--configuration-cache` at the same time.