### PR TITLE
Add properties to toggle which Gradle versions to integration test.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Gradle Version
         run: ./gradlew --version
       - name: Build
-        run: ./gradlew build -PtestAllSupportedGradleVersions=true
+        run: ./gradlew build -PtestMinimumSupportedGradleVersion=true -PtestCurrentGradleVersion=true
   macos:
     runs-on: macos-latest
     steps:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,9 +62,11 @@ tasks.test {
     if (project.hasProperty("skipIT")) {
         exclude("**/*_integTest*")
     }
-    if (project.hasProperty("testAllSupportedGradleVersions")) {
-        systemProperty("testAllSupportedGradleVersions", "true")
-    }
+    systemProperty("testAllSupportedGradleVersions", project.properties["testAllSupportedGradleVersions"] ?: "false")
+    systemProperty("testMinimumSupportedGradleVersion", project.properties["testMinimumSupportedGradleVersion"] ?: "false")
+    systemProperty("testMinimumCurrentGradleVersion", project.properties["testMinimumCurrentGradleVersion"] ?: "false")
+    systemProperty("testCurrentGradleVersion", project.properties["testCurrentGradleVersion"] ?: "true")
+
     val processorsCount = Runtime.getRuntime().availableProcessors()
     maxParallelForks = if (processorsCount > 2) processorsCount.div(2) else processorsCount
     testLogging {

--- a/src/test/groovy/com/github/gradle/RunWithMultipleGradleVersionsExtension.groovy
+++ b/src/test/groovy/com/github/gradle/RunWithMultipleGradleVersionsExtension.groovy
@@ -50,10 +50,21 @@ class RunWithMultipleGradleVersionsExtension extends AbstractAnnotationDrivenExt
     }
 
     private static GradleVersion[] computeCandidateGradleVersions() {
+        def versions = [CURRENT_GRADLE_VERSION]
         if (System.getProperty("testAllSupportedGradleVersions").equals("true")) {
             return GRADLE_VERSIONS
         }
-        return [CURRENT_GRADLE_VERSION]
+        if (System.getProperty("testMinimumSupportedGradleVersion").equals("true")) {
+            versions.add(MINIMUM_SUPPORTED_GRADLE_VERSION)
+        }
+        if (System.getProperty("testMinimumCurrentGradleVersion").equals("true")) {
+            versions.add(MINIMUM_GRADLE_6_VERSION)
+        }
+        if (System.getProperty("testCurrentGradleVersion").equals("false")) {
+            versions.remove(CURRENT_GRADLE_VERSION)
+        }
+
+        return versions
     }
 
     private static void enrichParameters(IMethodInvocation invocation, GradleVersion gradleVersion) {


### PR DESCRIPTION
This is to cut down on test time on Windows.

I've seen many cases where Windows takes 330+ minutes to finish, so I'm adding properties to toggle which version to test.
And changing Windows to only test `Current` and `Oldest supporter` (5.6.4)