### PR TITLE
Installation instructions: Fix repositories block

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -14,9 +14,7 @@ You can also install the plugins by using the traditional Gradle way:
 ```gradle
 buildscript {
   repositories {
-    maven {
-      gradlePluginPortal()
-    } 
+    gradlePluginPortal()
   }
 
   dependencies {


### PR DESCRIPTION
The `gradlePluginPortal()` function is used directly within the repositories block, not within a maven block.