### PR TITLE
Add tests for PlatformHelper arm functionality.

### DIFF
--- a/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
@@ -22,7 +22,7 @@ open class PlatformHelper constructor(private val props: Properties = System.get
              * As Java just returns "arm" on all ARM variants, we need a system call to determine the exact arch. Unfortunately some JVMs say aarch32/64, so we need an additional
              * conditional. Additionally, the node binaries for 'armv8l' are called 'arm64', so we need to distinguish here.
              */
-            arch == "arm" || arch.startsWith("aarch") -> execute("uname", "-m").mapIf({ it == "armv8l" }) { "arm64" }
+            arch == "arm" || arch.startsWith("aarch") -> property("uname").mapIf({ it == "armv8l" }) { "arm64" }
             arch.contains("64") -> "x64"
             else -> "x86"
         }
@@ -32,7 +32,10 @@ open class PlatformHelper constructor(private val props: Properties = System.get
 
     private fun property(name: String): String {
         val value = props.getProperty(name)
-        return value ?: System.getProperty(name) ?: error("Unable to find a value for property [$name].")
+        return value ?: System.getProperty(name) ?:
+            // Added so that we can test osArch on Windows and on non-arm systems
+            if (name == "uname") execute("uname", "-m")
+            else error("Unable to find a value for property [$name].")
     }
 
     companion object {

--- a/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
@@ -22,7 +22,8 @@ open class PlatformHelper constructor(private val props: Properties = System.get
              * As Java just returns "arm" on all ARM variants, we need a system call to determine the exact arch. Unfortunately some JVMs say aarch32/64, so we need an additional
              * conditional. Additionally, the node binaries for 'armv8l' are called 'arm64', so we need to distinguish here.
              */
-            arch == "arm" || arch.startsWith("aarch") -> property("uname").mapIf({ it == "armv8l" }) { "arm64" }
+            arch == "arm" || arch.startsWith("aarch") -> property("uname")
+                .mapIf({ it == "armv8l" || it == "aarch64" }) { "arm64" }
             arch.contains("64") -> "x64"
             else -> "x86"
         }

--- a/src/test/groovy/com/github/gradle/node/util/PlatformHelperTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/util/PlatformHelperTest.groovy
@@ -52,6 +52,7 @@ class PlatformHelperTest extends Specification {
         'arm'     | 'armv8l'  | 'arm64'
         'aarch32' | 'arm'     | 'arm'
         'aarch64' | 'arm64'   | 'arm64'
+        'aarch64' | 'aarch64' | 'arm64'
     }
 
     def "throw exception if unsupported os"() {

--- a/src/test/groovy/com/github/gradle/node/util/PlatformHelperTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/util/PlatformHelperTest.groovy
@@ -35,22 +35,23 @@ class PlatformHelperTest extends Specification {
         'SunOS'     | 'x86_64' | 'sunos'  | 'x64'  | false
     }
 
-    def "check that aarch32/64 is handled as arm"() {
-        when:
+    @Unroll
+    def "verify ARM handling #archProp (#unameProp)"() {
+        given:
         this.props.setProperty("os.name", "Linux")
-        this.props.setProperty("os.arch", "aarch64")
+        this.props.setProperty("os.arch", archProp)
+        this.props.setProperty("uname", unameProp)
 
-        then:
+        expect:
         this.helper.getOsName() == "linux"
-        this.helper.getOsArch() != "x64"
+        this.helper.getOsArch() == osArch
 
-        when:
-        this.props.setProperty("os.name", "Linux")
-        this.props.setProperty("os.arch", "aarch32")
-
-        then:
-        this.helper.getOsName() == "linux"
-        this.helper.getOsArch() != "x86"
+        where:
+        archProp  | unameProp | osArch
+        'arm'     | 'armv7l'  | 'armv7l' // Raspberry Pi 3
+        'arm'     | 'armv8l'  | 'arm64'
+        'aarch32' | 'arm'     | 'arm'
+        'aarch64' | 'arm64'   | 'arm64'
     }
 
     def "throw exception if unsupported os"() {


### PR DESCRIPTION
This moves the `uname -m` into the property `uname` to let us test the functionality on non-arm systems.