### PR TITLE
Update FAQ to be compatible with version 3.0.1

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -50,7 +50,7 @@ This can be done by adding to the arguments for the already defined `npmSetup` t
 ```gradle
 tasks.npmSetup {
     doFirst {
-        args = args + ['--registry', 'http://myregistry.npm.com']
+        args.addAll(['--registry', 'http://myregistry.npm.com'])
     }
 }
 ```


### PR DESCRIPTION
I'm not a Gradle expert but the present `args = argus + …` results in

```
* What went wrong:
Execution failed for task ':navigation-feedback-ui:npmSetup'.
> No signature of method: org.gradle.api.internal.provider.DefaultListProperty.plus() is applicable for argument types: (ArrayList) values: [[--registry, http://myregistry.npm.com]]
  Possible solutions: value(java.lang.Iterable), value(org.gradle.api.provider.Provider), value(java.lang.Iterable), value(org.gradle.api.provider.Provider), split(groovy.lang.Closure), use([Ljava.lang.Object;)
```