### PR TITLE
Open utility classes for external consumption.

### DIFF
--- a/src/main/kotlin/com/github/gradle/node/exec/ExecConfiguration.kt
+++ b/src/main/kotlin/com/github/gradle/node/exec/ExecConfiguration.kt
@@ -4,7 +4,7 @@ import org.gradle.api.Action
 import org.gradle.process.ExecSpec
 import java.io.File
 
-internal data class ExecConfiguration(
+data class ExecConfiguration(
         val executable: String,
         val args: List<String> = listOf(),
         val additionalBinPaths: List<String> = listOf(),

--- a/src/main/kotlin/com/github/gradle/node/exec/NodeExecConfiguration.kt
+++ b/src/main/kotlin/com/github/gradle/node/exec/NodeExecConfiguration.kt
@@ -4,7 +4,7 @@ import org.gradle.api.Action
 import org.gradle.process.ExecSpec
 import java.io.File
 
-internal data class NodeExecConfiguration(
+data class NodeExecConfiguration(
         val command: List<String> = listOf(),
         val environment: Map<String, String> = mapOf(),
         val workingDir: File? = null,

--- a/src/main/kotlin/com/github/gradle/node/exec/NodeExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/exec/NodeExecRunner.kt
@@ -7,33 +7,36 @@ import com.github.gradle.node.variant.VariantComputer
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 
-internal class NodeExecRunner {
+/**
+ * This function is responsible for setting up the configuration used when running the tasks.
+ */
+fun buildExecConfiguration(nodeExtension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration):
+        Provider<ExecConfiguration> {
+    val variantComputer = VariantComputer()
+    val nodeDirProvider = variantComputer.computeNodeDir(nodeExtension)
+    val nodeBinDirProvider = variantComputer.computeNodeBinDir(nodeDirProvider)
+    val executableProvider = variantComputer.computeNodeExec(nodeExtension, nodeBinDirProvider)
+    val additionalBinPathProvider = computeAdditionalBinPath(nodeExtension, nodeBinDirProvider)
+    return zip(executableProvider, additionalBinPathProvider)
+        .map { (executable, additionalBinPath) ->
+            ExecConfiguration(executable, nodeExecConfiguration.command, additionalBinPath,
+                nodeExecConfiguration.environment, nodeExecConfiguration.workingDir,
+                nodeExecConfiguration.ignoreExitValue, nodeExecConfiguration.execOverrides)
+        }
+}
+
+fun computeAdditionalBinPath(nodeExtension: NodeExtension, nodeBinDirProvider: Provider<Directory>):
+        Provider<List<String>> {
+    return zip(nodeExtension.download, nodeBinDirProvider)
+        .map { (download, nodeBinDir) ->
+            if (download) listOf(nodeBinDir.asFile.absolutePath) else listOf()
+        }
+}
+
+class NodeExecRunner {
     fun execute(project: ProjectApiHelper, extension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration) {
         val execConfiguration = buildExecConfiguration(extension, nodeExecConfiguration).get()
         val execRunner = ExecRunner()
         execRunner.execute(project, extension, execConfiguration)
-    }
-
-    private fun buildExecConfiguration(nodeExtension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration):
-            Provider<ExecConfiguration> {
-        val variantComputer = VariantComputer()
-        val nodeDirProvider = variantComputer.computeNodeDir(nodeExtension)
-        val nodeBinDirProvider = variantComputer.computeNodeBinDir(nodeDirProvider)
-        val executableProvider = variantComputer.computeNodeExec(nodeExtension, nodeBinDirProvider)
-        val additionalBinPathProvider = computeAdditionalBinPath(nodeExtension, nodeBinDirProvider)
-        return zip(executableProvider, additionalBinPathProvider)
-                .map { (executable, additionalBinPath) ->
-                    ExecConfiguration(executable, nodeExecConfiguration.command, additionalBinPath,
-                            nodeExecConfiguration.environment, nodeExecConfiguration.workingDir,
-                            nodeExecConfiguration.ignoreExitValue, nodeExecConfiguration.execOverrides)
-                }
-    }
-
-    private fun computeAdditionalBinPath(nodeExtension: NodeExtension, nodeBinDirProvider: Provider<Directory>):
-            Provider<List<String>> {
-        return zip(nodeExtension.download, nodeBinDirProvider)
-                .map { (download, nodeBinDir) ->
-                    if (download) listOf(nodeBinDir.asFile.absolutePath) else listOf()
-                }
     }
 }

--- a/src/main/kotlin/com/github/gradle/node/npm/exec/NpmExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/exec/NpmExecRunner.kt
@@ -14,7 +14,7 @@ import org.gradle.api.provider.ProviderFactory
 import java.io.File
 import javax.inject.Inject
 
-internal abstract class NpmExecRunner {
+abstract class NpmExecRunner {
     @get:Inject
     abstract val providers: ProviderFactory
 

--- a/src/main/kotlin/com/github/gradle/node/npm/proxy/NpmProxy.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/proxy/NpmProxy.kt
@@ -5,7 +5,7 @@ import java.util.stream.Collectors.toList
 import java.util.stream.Stream
 import kotlin.text.Charsets.UTF_8
 
-internal class NpmProxy {
+class NpmProxy {
 
     companion object {
         // These are the environment variables that HTTPing applications checks, proxy is on and off.
@@ -28,6 +28,11 @@ internal class NpmProxy {
             return proxyEnvironmentVariables.toMap()
         }
 
+        /**
+         * Helper function for deciding whether to set proxy settings or not.
+         *
+         * If you make use of
+         */
         fun shouldConfigureProxy(env: Map<String, String>, settings: ProxySettings): Boolean {
             if (settings == ProxySettings.FORCED) {
                 return true

--- a/src/main/kotlin/com/github/gradle/node/util/ProjectApiHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/ProjectApiHelper.kt
@@ -43,7 +43,7 @@ interface ProjectApiHelper {
     fun exec(action: Action<ExecSpec>): ExecResult
 }
 
-internal open class DefaultProjectApiHelper @Inject constructor(
+open class DefaultProjectApiHelper @Inject constructor(
         private val factory: ObjectFactory,
         private val execOperations: ExecOperations,
         private val fileSystemOperations: FileSystemOperations,
@@ -74,7 +74,7 @@ internal open class DefaultProjectApiHelper @Inject constructor(
     }
 }
 
-internal open class LegacyProjectApiHelper(private val project: Project) : ProjectApiHelper {
+open class LegacyProjectApiHelper(private val project: Project) : ProjectApiHelper {
 
     override fun fileTree(directory: Directory): ConfigurableFileTree {
         return project.fileTree(directory)

--- a/src/main/kotlin/com/github/gradle/node/variant/VariantComputer.kt
+++ b/src/main/kotlin/com/github/gradle/node/variant/VariantComputer.kt
@@ -7,7 +7,7 @@ import com.github.gradle.node.util.zip
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 
-internal class VariantComputer @JvmOverloads constructor(
+open class VariantComputer @JvmOverloads constructor(
         private val platformHelper: PlatformHelper = PlatformHelper.INSTANCE
 ) {
     fun computeNodeDir(nodeExtension: NodeExtension): Provider<Directory> {

--- a/src/main/kotlin/com/github/gradle/node/yarn/exec/YarnExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/exec/YarnExecRunner.kt
@@ -13,7 +13,7 @@ import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
 import javax.inject.Inject
 
-internal abstract class YarnExecRunner {
+abstract class YarnExecRunner {
     @get:Inject
     abstract val providers: ProviderFactory
 

--- a/src/test/groovy/com/github/gradle/node/SystemVersion_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/SystemVersion_integTest.groovy
@@ -29,11 +29,11 @@ class SystemVersion_integTest extends AbstractIntegTest {
         result2.output.contains("Project repositories: 0")
 
         when:
-        def result3 = build(":npmHelp")
+        def result3 = build(":npmVersion")
 
         then:
-        result3.task(":npmHelp").outcome == TaskOutcome.SUCCESS
-        result3.output.contains("Usage: npm <command>")
+        result3.task(":npmVersion").outcome == TaskOutcome.SUCCESS
+        result3.output.contains("  npm: '")
 
         when:
         def result4 = build(":npxHelp")

--- a/src/test/groovy/com/github/gradle/node/SystemVersion_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/SystemVersion_integTest.groovy
@@ -40,7 +40,7 @@ class SystemVersion_integTest extends AbstractIntegTest {
 
         then:
         result4.task(":npxHelp").outcome == TaskOutcome.SUCCESS
-        result4.output.contains("npx --shell-auto-fallback [shell]")
+        result4.output.contains("Run a command from a local or remote npm package")
 
         when:
         def result5 = build(":yarnHelp")

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
@@ -118,7 +118,7 @@ class NpmInstall_integTest extends AbstractIntegTest {
         def result = buildAndFail('npmInstall')
 
         then:
-        result.output.contains('can only install packages with an existing package-lock.json')
+        result.output.contains('can only install with an existing package-lock.json')
         result.task(':npmInstall').outcome == TaskOutcome.FAILED
 
         when:

--- a/src/test/resources/fixtures/node-system-version/build.gradle
+++ b/src/test/resources/fixtures/node-system-version/build.gradle
@@ -13,9 +13,8 @@ task countRepositories {
     }
 }
 
-task npmHelp(type: NpmTask) {
-    npmCommand = ["--help"]
-    ignoreExitValue = true
+task npmVersion(type: NpmTask) {
+    npmCommand = ["version"]
 }
 
 task npxHelp(type: NpxTask) {


### PR DESCRIPTION
Make the `ExecRunners` (and depending classes) public to allow for external users to use these to extend functionality.

This is the simpler solution compared to subclassing the tasks