### PR TITLE
Proper Mac M1 support, updated node, npm and yarn

### DIFF
--- a/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
@@ -17,17 +17,30 @@ open class PlatformHelper constructor(private val props: Properties = System.get
 
     open val osArch: String by lazy {
         val arch = property("os.arch").toLowerCase()
-        when {
-            /*
-             * As Java just returns "arm" on all ARM variants, we need a system call to determine the exact arch. Unfortunately some JVMs say aarch32/64, so we need an additional
-             * conditional. Additionally, the node binaries for 'armv8l' are called 'arm64', so we need to distinguish here.
-             */
-            arch == "arm" || arch.startsWith("aarch") -> property("uname")
-                .mapIf({ it == "armv8l" || it == "aarch64" }) { "arm64" }
-            arch == "ppc64le" -> "ppc64le"
-            arch == "s390x" -> "s390x"
-            arch.contains("64") -> "x64"
-            else -> "x86"
+        when (osName) {
+            "darwin" -> {
+                /**
+                 * As "uname" in M1 Mac always returns "x86_64" value it's not possible to determine in general way
+                 * (as below) correct architecture. The good way first to check for osName and then decide the arch.
+                 */
+                if (arch == "aarch64") {
+                    return@lazy "arm64"
+                } else {
+                    return@lazy "x86"
+                }
+            }
+            else -> when {
+                /*
+                 * As Java just returns "arm" on all ARM variants, we need a system call to determine the exact arch. Unfortunately some JVMs say aarch32/64, so we need an additional
+                 * conditional. Additionally, the node binaries for 'armv8l' are called 'arm64', so we need to distinguish here.
+                 */
+                arch == "arm" || arch.startsWith("aarch") -> property("uname")
+                    .mapIf({ it == "armv8l" || it == "aarch64" }) { "arm64" }
+                arch == "ppc64le" -> "ppc64le"
+                arch == "s390x" -> "s390x"
+                arch.contains("64") -> "x64"
+                else -> "x86"
+            }
         }
     }
 

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmInstall_integTest.groovy
@@ -48,8 +48,8 @@ class NpmInstall_integTest extends AbstractIntegTest {
             
             node {
                 download = true
-                version = '15.2.1'
-                npmVersion = '7.0.1'
+                version = '17.1.0'
+                npmVersion = '8.1.0'
             }
         ''')
         writeEmptyPackageJson()

--- a/src/test/groovy/com/github/gradle/node/yarn/task/YarnInstall_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/yarn/task/YarnInstall_integTest.groovy
@@ -46,8 +46,8 @@ class YarnInstall_integTest extends AbstractIntegTest {
             node {
                 download = true
                 yarnWorkDir = file('build/yarn')
-                version = '15.2.1'
-                npmVersion = '7.0.1'
+                version = '17.1.0'
+                npmVersion = '8.1.0'
             }
         ''')
         writeEmptyPackageJson()

--- a/src/test/resources/fixtures/node-allow-insecure-protocol/build.gradle
+++ b/src/test/resources/fixtures/node-allow-insecure-protocol/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 node {
-    version = "12.13.0"
+    version = "17.1.0"
     distBaseUrl = "http://nodejs.org/dist/"
     download = true
     allowInsecureProtocol = true

--- a/src/test/resources/fixtures/node-disallow-insecure-protocol/build.gradle
+++ b/src/test/resources/fixtures/node-disallow-insecure-protocol/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 node {
-    version = "12.13.0"
+    version = "17.1.0"
     distBaseUrl = "https://nodejs.org/dist/"
     download = true
     allowInsecureProtocol = false

--- a/src/test/resources/fixtures/node-fail-on-project-repos-download/build.gradle
+++ b/src/test/resources/fixtures/node-fail-on-project-repos-download/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 node {
-    version = "12.13.0"
+    version = "17.1.0"
     distBaseUrl = null
     download = true
     workDir = file("build/node")

--- a/src/test/resources/fixtures/node/build.gradle
+++ b/src/test/resources/fixtures/node/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 node {
-    version = "12.13.0"
+    version = "17.1.0"
     download = true
     workDir = file("build/node")
 }

--- a/src/test/resources/fixtures/npm/build.gradle
+++ b/src/test/resources/fixtures/npm/build.gradle
@@ -7,7 +7,7 @@ plugins {
 def changeInputs = isPropertyEnabled("changeInputs")
 
 node {
-    npmVersion = "6.12.0"
+    npmVersion = "8.1.0"
     download = true
     workDir = file('build/node')
 }

--- a/src/test/resources/fixtures/npx/build.gradle
+++ b/src/test/resources/fixtures/npx/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 node {
-    npmVersion = "6.12.0"
+    npmVersion = "8.1.0"
     download = true
     workDir = file("build/node")
 }

--- a/src/test/resources/fixtures/yarn/build.gradle
+++ b/src/test/resources/fixtures/yarn/build.gradle
@@ -7,7 +7,7 @@ plugins {
 def changeInputs = isPropertyEnabled("changeInputs")
 
 node {
-    yarnVersion = "1.18.0"
+    yarnVersion = "1.22.17"
     download = true
     workDir = file("build/node")
 }


### PR DESCRIPTION
As "uname" syscall in M1 Mac always returns "x86_64" on some Java builds, this value it's not possible to determine in a general way (as previously was described in osArch field lazy block) correct architecture. The good way is first to check for osName and then decide the arch. 

- Fixed checking for darwin aarch64
- Updated node, npm, and yarn to be able to download darwin aarch64 versions