### PR TITLE
Support Gradle 7.4 configuration caching

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,9 +6,9 @@ jobs:
     strategy:
       matrix:
         config:
-          - {os: ubuntu-latest, params: "-PtestAllSupportedGradleVersions=true -PtestProxyIntegrationTests=false" }
-          - {os: windows-latest, params: "-PtestProxyIntegrationTests=false" }
-          - {os: macos-latest, params: "-PtestProxyIntegrationTests=false" }
+          - {os: ubuntu-latest, params: "-PtestAllSupportedGradleVersions=true" }
+          - {os: windows-latest, params: "" }
+          - {os: macos-latest, params: "" }
     steps:
       - name: Checkout Source Code
         uses: actions/checkout@v2

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,6 @@ tasks.test {
     )
     systemProperty("testMinimumCurrentGradleVersion", project.properties["testMinimumCurrentGradleVersion"] ?: "false")
     systemProperty("testCurrentGradleVersion", project.properties["testCurrentGradleVersion"] ?: "true")
-    systemProperty("testProxyIntegrationTests", project.properties["testProxyIntegrationTests"] ?: "true")
 
     val processorsCount = Runtime.getRuntime().availableProcessors()
     maxParallelForks = if (processorsCount > 2) processorsCount.div(2) else processorsCount

--- a/src/main/kotlin/com/github/gradle/node/NodePlugin.kt
+++ b/src/main/kotlin/com/github/gradle/node/NodePlugin.kt
@@ -107,13 +107,12 @@ class NodePlugin : Plugin<Project> {
     }
 
     private fun configureNodeSetupTask(nodeExtension: NodeExtension) {
-        val variantComputer = VariantComputer()
-        val nodeArchiveDependencyProvider = variantComputer.computeNodeArchiveDependency(nodeExtension)
-        val archiveFileProvider = nodeArchiveDependencyProvider
-                .map { nodeArchiveDependency ->
-                    resolveNodeArchiveFile(nodeArchiveDependency)
-                }
         project.tasks.named<NodeSetupTask>(NodeSetupTask.NAME) {
+            val nodeArchiveDependencyProvider = variantComputer.computeNodeArchiveDependency(nodeExtension)
+            val archiveFileProvider = nodeArchiveDependencyProvider
+                    .map { nodeArchiveDependency ->
+                        resolveNodeArchiveFile(nodeArchiveDependency)
+                    }
             nodeArchiveFile.set(project.layout.file(archiveFileProvider))
         }
     }

--- a/src/main/kotlin/com/github/gradle/node/exec/NodeExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/exec/NodeExecRunner.kt
@@ -10,9 +10,8 @@ import org.gradle.api.provider.Provider
 /**
  * This function is responsible for setting up the configuration used when running the tasks.
  */
-fun buildExecConfiguration(nodeExtension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration):
+fun buildExecConfiguration(nodeExtension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration, variantComputer: VariantComputer):
         Provider<ExecConfiguration> {
-    val variantComputer = VariantComputer()
     val nodeDirProvider = variantComputer.computeNodeDir(nodeExtension)
     val nodeBinDirProvider = variantComputer.computeNodeBinDir(nodeDirProvider)
     val executableProvider = variantComputer.computeNodeExec(nodeExtension, nodeBinDirProvider)
@@ -34,8 +33,8 @@ fun computeAdditionalBinPath(nodeExtension: NodeExtension, nodeBinDirProvider: P
 }
 
 class NodeExecRunner {
-    fun execute(project: ProjectApiHelper, extension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration) {
-        val execConfiguration = buildExecConfiguration(extension, nodeExecConfiguration).get()
+    fun execute(project: ProjectApiHelper, extension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration, variantComputer: VariantComputer) {
+        val execConfiguration = buildExecConfiguration(extension, nodeExecConfiguration, variantComputer).get()
         val execRunner = ExecRunner()
         execRunner.execute(project, extension, execConfiguration)
     }

--- a/src/main/kotlin/com/github/gradle/node/npm/task/NpmSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/task/NpmSetupTask.kt
@@ -4,10 +4,9 @@ import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.exec.NodeExecConfiguration
 import com.github.gradle.node.npm.exec.NpmExecRunner
+import com.github.gradle.node.task.BaseTask
 import com.github.gradle.node.task.NodeSetupTask
 import com.github.gradle.node.util.ProjectApiHelper
-import com.github.gradle.node.variant.VariantComputer
-import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.ProviderFactory
@@ -22,7 +21,7 @@ import javax.inject.Inject
 /**
  * npm install that only gets executed if gradle decides so.
  */
-abstract class NpmSetupTask : DefaultTask() {
+abstract class NpmSetupTask : BaseTask() {
 
     @get:Inject
     abstract val objects: ObjectFactory
@@ -44,7 +43,6 @@ abstract class NpmSetupTask : DefaultTask() {
 
     @get:OutputDirectory
     val npmDir by lazy {
-        val variantComputer = VariantComputer()
         val nodeDir = variantComputer.computeNodeDir(nodeExtension)
         variantComputer.computeNpmDir(nodeExtension, nodeDir)
     }
@@ -73,7 +71,7 @@ abstract class NpmSetupTask : DefaultTask() {
         val command = computeCommand()
         val nodeExecConfiguration = NodeExecConfiguration(command)
         val npmExecRunner = objects.newInstance(NpmExecRunner::class.java)
-        npmExecRunner.executeNpmCommand(projectHelper, nodeExtension, nodeExecConfiguration)
+        npmExecRunner.executeNpmCommand(projectHelper, nodeExtension, nodeExecConfiguration, variantComputer)
     }
 
     protected open fun computeCommand(): List<String> {

--- a/src/main/kotlin/com/github/gradle/node/npm/task/NpmTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/task/NpmTask.kt
@@ -4,9 +4,9 @@ import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.exec.NodeExecConfiguration
 import com.github.gradle.node.npm.exec.NpmExecRunner
+import com.github.gradle.node.task.BaseTask
 import com.github.gradle.node.util.ProjectApiHelper
 import org.gradle.api.Action
-import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
@@ -19,7 +19,7 @@ import org.gradle.kotlin.dsl.property
 import org.gradle.process.ExecSpec
 import javax.inject.Inject
 
-abstract class NpmTask : DefaultTask() {
+abstract class NpmTask : BaseTask() {
     @get:Inject
     abstract val objects: ObjectFactory
 
@@ -70,6 +70,6 @@ abstract class NpmTask : DefaultTask() {
                 NodeExecConfiguration(command, environment.get(), workingDir.asFile.orNull, ignoreExitValue.get(),
                         execOverrides.orNull)
         val npmExecRunner = objects.newInstance(NpmExecRunner::class.java)
-        npmExecRunner.executeNpmCommand(projectHelper, nodeExtension, nodeExecConfiguration)
+        npmExecRunner.executeNpmCommand(projectHelper, nodeExtension, nodeExecConfiguration, variantComputer)
     }
 }

--- a/src/main/kotlin/com/github/gradle/node/npm/task/NpxTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/npm/task/NpxTask.kt
@@ -4,9 +4,9 @@ import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.exec.NodeExecConfiguration
 import com.github.gradle.node.npm.exec.NpmExecRunner
+import com.github.gradle.node.task.BaseTask
 import com.github.gradle.node.util.ProjectApiHelper
 import org.gradle.api.Action
-import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
@@ -18,7 +18,7 @@ import org.gradle.kotlin.dsl.property
 import org.gradle.process.ExecSpec
 import javax.inject.Inject
 
-abstract class NpxTask : DefaultTask() {
+abstract class NpxTask : BaseTask() {
 
     @get:Inject
     abstract val objects: ObjectFactory
@@ -70,6 +70,6 @@ abstract class NpxTask : DefaultTask() {
                 NodeExecConfiguration(fullCommand, environment.get(), workingDir.asFile.orNull,
                         ignoreExitValue.get(), execOverrides.orNull)
         val npmExecRunner = objects.newInstance(NpmExecRunner::class.java)
-        npmExecRunner.executeNpxCommand(projectHelper, extension, nodeExecConfiguration)
+        npmExecRunner.executeNpxCommand(projectHelper, extension, nodeExecConfiguration, variantComputer)
     }
 }

--- a/src/main/kotlin/com/github/gradle/node/task/BaseTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/task/BaseTask.kt
@@ -1,0 +1,18 @@
+package com.github.gradle.node.task
+
+import com.github.gradle.node.util.PlatformHelper
+import com.github.gradle.node.variant.VariantComputer
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Internal
+
+abstract class BaseTask : DefaultTask() {
+
+    @get:Internal
+    var platformHelper = PlatformHelper.INSTANCE
+
+    @get:Internal
+    internal val variantComputer by lazy {
+        VariantComputer(platformHelper)
+    }
+
+}

--- a/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/task/NodeSetupTask.kt
@@ -2,10 +2,8 @@ package com.github.gradle.node.task
 
 import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
-import com.github.gradle.node.util.PlatformHelper
 import com.github.gradle.node.util.ProjectApiHelper
 import com.github.gradle.node.variant.VariantComputer
-import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.*
@@ -14,7 +12,7 @@ import java.nio.file.Files
 import java.nio.file.Paths
 import javax.inject.Inject
 
-abstract class NodeSetupTask : DefaultTask() {
+abstract class NodeSetupTask : BaseTask() {
 
     @get:Inject
     abstract val objects: ObjectFactory
@@ -22,7 +20,6 @@ abstract class NodeSetupTask : DefaultTask() {
     @get:Inject
     abstract val providers: ProviderFactory
 
-    private val variantComputer = VariantComputer()
     private val nodeExtension = NodeExtension[project]
 
     @get:Input
@@ -90,7 +87,7 @@ abstract class NodeSetupTask : DefaultTask() {
     }
 
     private fun setExecutableFlag() {
-        if (!PlatformHelper.INSTANCE.isWindows) {
+        if (!platformHelper.isWindows) {
             val nodeDirProvider = variantComputer.computeNodeDir(nodeExtension)
             val nodeBinDirProvider = variantComputer.computeNodeBinDir(nodeDirProvider)
             val nodeExecProvider = variantComputer.computeNodeExec(nodeExtension, nodeBinDirProvider)

--- a/src/main/kotlin/com/github/gradle/node/task/NodeTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/task/NodeTask.kt
@@ -6,7 +6,6 @@ import com.github.gradle.node.exec.NodeExecConfiguration
 import com.github.gradle.node.exec.NodeExecRunner
 import com.github.gradle.node.util.ProjectApiHelper
 import org.gradle.api.Action
-import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.*
@@ -20,7 +19,7 @@ import javax.inject.Inject
 /**
  * Gradle task for running a Node.js script
  */
-abstract class NodeTask : DefaultTask() {
+abstract class NodeTask : BaseTask() {
     @get:Inject
     abstract val objects: ObjectFactory
 
@@ -95,6 +94,6 @@ abstract class NodeTask : DefaultTask() {
                 NodeExecConfiguration(command, environment.get(), workingDir.asFile.orNull,
                         ignoreExitValue.get(), execOverrides.orNull)
         val nodeExecRunner = NodeExecRunner()
-        nodeExecRunner.execute(projectHelper, extension, nodeExecConfiguration)
+        nodeExecRunner.execute(projectHelper, extension, nodeExecConfiguration, variantComputer)
     }
 }

--- a/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
@@ -2,7 +2,7 @@ package com.github.gradle.node.util
 
 import java.util.*
 
-open class PlatformHelper constructor(private val props: Properties = System.getProperties()) {
+open class PlatformHelper {
     open val osName: String by lazy {
         val name = property("os.name").toLowerCase()
         when {
@@ -34,11 +34,14 @@ open class PlatformHelper constructor(private val props: Properties = System.get
     open val isWindows: Boolean by lazy { osName == "win" }
 
     private fun property(name: String): String {
-        val value = props.getProperty(name)
-        return value ?: System.getProperty(name) ?:
+        return getSystemProperty(name) ?:
             // Added so that we can test osArch on Windows and on non-arm systems
             if (name == "uname") execute("uname", "-m")
             else error("Unable to find a value for property [$name].")
+    }
+
+    open fun getSystemProperty(name: String): String? {
+        return System.getProperty(name);
     }
 
     companion object {

--- a/src/main/kotlin/com/github/gradle/node/variant/VariantComputer.kt
+++ b/src/main/kotlin/com/github/gradle/node/variant/VariantComputer.kt
@@ -7,8 +7,8 @@ import com.github.gradle.node.util.zip
 import org.gradle.api.file.Directory
 import org.gradle.api.provider.Provider
 
-open class VariantComputer @JvmOverloads constructor(
-        private val platformHelper: PlatformHelper = PlatformHelper.INSTANCE
+open class VariantComputer constructor(
+        private val platformHelper: PlatformHelper
 ) {
     /**
      * Get the expected directory for a given node version.

--- a/src/main/kotlin/com/github/gradle/node/yarn/exec/YarnExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/exec/YarnExecRunner.kt
@@ -17,15 +17,18 @@ abstract class YarnExecRunner {
     @get:Inject
     abstract val providers: ProviderFactory
 
-    private val variantComputer = VariantComputer()
-
-    fun executeYarnCommand(project: ProjectApiHelper, nodeExtension: NodeExtension, nodeExecConfiguration: NodeExecConfiguration) {
+    fun executeYarnCommand(
+        project: ProjectApiHelper,
+        nodeExtension: NodeExtension,
+        nodeExecConfiguration: NodeExecConfiguration,
+        variantComputer: VariantComputer
+    ) {
         val nodeDirProvider = variantComputer.computeNodeDir(nodeExtension)
         val yarnDirProvider = variantComputer.computeYarnDir(nodeExtension)
         val yarnBinDirProvider = variantComputer.computeYarnBinDir(yarnDirProvider)
         val yarnExecProvider = variantComputer.computeYarnExec(nodeExtension, yarnBinDirProvider)
         val additionalBinPathProvider =
-                computeAdditionalBinPath(nodeExtension, nodeDirProvider, yarnBinDirProvider)
+                computeAdditionalBinPath(nodeExtension, nodeDirProvider, yarnBinDirProvider, variantComputer)
         val execConfiguration = ExecConfiguration(yarnExecProvider.get(),
                 nodeExecConfiguration.command, additionalBinPathProvider.get(),
                 addNpmProxyEnvironment(nodeExtension, nodeExecConfiguration), nodeExecConfiguration.workingDir,
@@ -45,9 +48,12 @@ abstract class YarnExecRunner {
         return nodeExecConfiguration.environment
     }
 
-    private fun computeAdditionalBinPath(nodeExtension: NodeExtension,
-                                         nodeDirProvider: Provider<Directory>,
-                                         yarnBinDirProvider: Provider<Directory>): Provider<List<String>> {
+    private fun computeAdditionalBinPath(
+        nodeExtension: NodeExtension,
+        nodeDirProvider: Provider<Directory>,
+        yarnBinDirProvider: Provider<Directory>,
+        variantComputer: VariantComputer
+    ): Provider<List<String>> {
         return nodeExtension.download.flatMap { download ->
             if (!download) {
                 providers.provider { listOf<String>() }

--- a/src/main/kotlin/com/github/gradle/node/yarn/task/YarnSetupTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/task/YarnSetupTask.kt
@@ -24,7 +24,6 @@ abstract class YarnSetupTask : NpmSetupTask() {
 
     @get:OutputDirectory
     val yarnDir by lazy {
-        val variantComputer = VariantComputer()
         variantComputer.computeYarnDir(nodeExtension)
     }
 

--- a/src/main/kotlin/com/github/gradle/node/yarn/task/YarnTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/yarn/task/YarnTask.kt
@@ -3,10 +3,10 @@ package com.github.gradle.node.yarn.task
 import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.NodePlugin
 import com.github.gradle.node.exec.NodeExecConfiguration
+import com.github.gradle.node.task.BaseTask
 import com.github.gradle.node.util.ProjectApiHelper
 import com.github.gradle.node.yarn.exec.YarnExecRunner
 import org.gradle.api.Action
-import org.gradle.api.DefaultTask
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
@@ -19,7 +19,7 @@ import org.gradle.kotlin.dsl.property
 import org.gradle.process.ExecSpec
 import javax.inject.Inject
 
-abstract class YarnTask : DefaultTask() {
+abstract class YarnTask : BaseTask() {
 
     @get:Inject
     abstract val objects: ObjectFactory
@@ -71,6 +71,6 @@ abstract class YarnTask : DefaultTask() {
                 NodeExecConfiguration(command, environment.get(), workingDir.asFile.orNull,
                         ignoreExitValue.get(), execOverrides.orNull)
         val yarnExecRunner = objects.newInstance(YarnExecRunner::class.java)
-        yarnExecRunner.executeYarnCommand(projectHelper, nodeExtension, nodeExecConfiguration)
+        yarnExecRunner.executeYarnCommand(projectHelper, nodeExtension, nodeExecConfiguration, variantComputer)
     }
 }

--- a/src/test/groovy/com/github/gradle/RunWithMultipleGradleVersionsExtension.groovy
+++ b/src/test/groovy/com/github/gradle/RunWithMultipleGradleVersionsExtension.groovy
@@ -15,8 +15,10 @@ class RunWithMultipleGradleVersionsExtension extends AbstractAnnotationDrivenExt
     private static final GradleVersion MINIMUM_GRADLE_6_VERSION = GradleVersion.version("6.0")
     private static final GradleVersion CURRENT_GRADLE_VERSION = GradleVersion.current()
     private static final GradleVersion GRADLE_7_VERSION = GradleVersion.version("7.0")
+    private static final GradleVersion GRADLE_7RC_VERSION = GradleVersion.version("7.4-rc-1")
     private static final GradleVersion[] GRADLE_VERSIONS =
-            [MINIMUM_SUPPORTED_GRADLE_VERSION, MINIMUM_GRADLE_6_VERSION, CURRENT_GRADLE_VERSION, GRADLE_7_VERSION]
+            [MINIMUM_SUPPORTED_GRADLE_VERSION, MINIMUM_GRADLE_6_VERSION, CURRENT_GRADLE_VERSION, GRADLE_7_VERSION,
+             GRADLE_7RC_VERSION]
     private GradleVersion gradleVersion
 
     @Override

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmInstallTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmInstallTaskTest.groovy
@@ -16,6 +16,7 @@ class NpmInstallTaskTest extends AbstractTaskTest {
         GradleProxyHelper.setHttpsProxyPort(11235)
 
         def task = project.tasks.getByName("npmInstall")
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
 
         when:
@@ -36,6 +37,7 @@ class NpmInstallTaskTest extends AbstractTaskTest {
         nodeExtension.nodeProxySettings.set(ProxySettings.OFF)
 
         def task = project.tasks.getByName("npmInstall")
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
 
         when:

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmProxy_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmProxy_integTest.groovy
@@ -46,15 +46,8 @@ class NpmProxy_integTest extends AbstractIntegTest {
         } else {
             proxyMockServer.verify(request()
                     .withMethod("GET")
-                    .withSecure(secure)
                     .withPath("/case")
-                    .withHeader("Host", "registry.npmjs.org:${port}"),
-                    exactly(1))
-            proxyMockServer.verify(request()
-                    .withMethod("POST")
-                    .withSecure(secure)
-                    .withPath("/-/npm/v1/security/audits/quick")
-                    .withHeader("Host", "registry.npmjs.org:${port}"),
+                    .withHeader("Host", "registry.npmjs.org.*"),
                     exactly(1))
         }
 
@@ -94,15 +87,8 @@ class NpmProxy_integTest extends AbstractIntegTest {
         createFile("node_modules/case/package.json").exists()
         proxyMockServer.verify(request()
                 .withMethod("GET")
-                .withSecure(false)
                 .withPath("/case")
-                .withHeader("Host", "registry.npmjs.org:${port}"),
-                exactly(1))
-        proxyMockServer.verify(request()
-                .withMethod("POST")
-                .withSecure(false)
-                .withPath("/-/npm/v1/security/audits/quick")
-                .withHeader("Host", "registry.npmjs.org:${port}"),
+                .withHeader("Host", "registry.npmjs.org.*"),
                 exactly(1))
     }
 }

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmProxy_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmProxy_integTest.groovy
@@ -5,13 +5,11 @@ import com.github.gradle.node.ProxyTestHelper
 import org.gradle.testkit.runner.TaskOutcome
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.socket.PortFactory
-import spock.lang.Requires
 
 import static org.mockserver.integration.ClientAndServer.startClientAndServer
 import static org.mockserver.model.HttpRequest.request
 import static org.mockserver.verify.VerificationTimes.exactly
 
-@Requires({ System.getProperty("testProxyIntegrationTests").equals("true") })
 class NpmProxy_integTest extends AbstractIntegTest {
     private ClientAndServer proxyMockServer
 

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmSetupTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmSetupTaskTest.groovy
@@ -2,7 +2,6 @@ package com.github.gradle.node.npm.task
 
 import com.github.gradle.node.npm.proxy.GradleProxyHelper
 import com.github.gradle.node.task.AbstractTaskTest
-import org.gradle.process.ExecSpec
 
 class NpmSetupTaskTest extends AbstractTaskTest {
     def cleanup() {
@@ -14,6 +13,7 @@ class NpmSetupTaskTest extends AbstractTaskTest {
         props.setProperty('os.name', 'Linux')
 
         def task = project.tasks.create('simple', NpmSetupTask)
+        mockPlatformHelper(task)
 
         when:
         project.evaluate()
@@ -28,6 +28,7 @@ class NpmSetupTaskTest extends AbstractTaskTest {
         nodeExtension.npmVersion.set('6.4.1')
 
         def task = project.tasks.create('simple', NpmSetupTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
 
         when:
@@ -51,6 +52,7 @@ class NpmSetupTaskTest extends AbstractTaskTest {
         GradleProxyHelper.setHttpProxyPort(1234)
 
         def task = project.tasks.create('simple', NpmSetupTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
 
         when:

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmTaskTest.groovy
@@ -16,6 +16,7 @@ class NpmTaskTest extends AbstractTaskTest {
         props.setProperty('os.name', 'Linux')
 
         def task = project.tasks.create('simple', NpmTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
         task.environment.set(['a': '1'])
@@ -38,6 +39,7 @@ class NpmTaskTest extends AbstractTaskTest {
         props.setProperty('os.name', 'Windows')
 
         def task = project.tasks.create('simple', NpmTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
         task.environment.set(['a': '1'])
@@ -63,6 +65,7 @@ class NpmTaskTest extends AbstractTaskTest {
                 .resolve("node-v${DEFAULT_NODE_VERSION}-linux-x64")
 
         def task = project.tasks.create('simple', NpmTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 
@@ -94,6 +97,7 @@ class NpmTaskTest extends AbstractTaskTest {
         GradleProxyHelper.setHttpProxyPort(123)
 
         def task = project.tasks.create('simple', NpmTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 
@@ -123,6 +127,7 @@ class NpmTaskTest extends AbstractTaskTest {
         GradleProxyHelper.setHttpsProxyPort(11235)
 
         def task = project.tasks.create('simple', NpmTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
 
@@ -144,6 +149,7 @@ class NpmTaskTest extends AbstractTaskTest {
         nodeExtension.nodeProxySettings.set(ProxySettings.OFF)
 
         def task = project.tasks.create('simple', NpmTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
 

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpxTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpxTaskTest.groovy
@@ -9,6 +9,7 @@ class NpxTaskTest extends AbstractTaskTest {
         props.setProperty('os.name', 'Linux')
 
         def task = project.tasks.create('simple', NpxTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.command.set('command')
         task.args.set(['a', 'b'])
@@ -35,6 +36,7 @@ class NpxTaskTest extends AbstractTaskTest {
         props.setProperty('os.name', 'Windows')
 
         def task = project.tasks.create('simple', NpxTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.command.set('command')
         task.args.set(['a', 'b'])
@@ -60,12 +62,13 @@ class NpxTaskTest extends AbstractTaskTest {
         given:
         props.setProperty('os.name', 'Linux')
         nodeExtension.download.set(true)
-        def variantComputer = new VariantComputer()
+        def variantComputer = new VariantComputer(testPlatformHelper)
         def nodeDir = variantComputer.computeNodeDir(nodeExtension)
         def nodeBinDir = variantComputer.computeNodeBinDir(nodeDir)
         def npxScriptFile = variantComputer.computeNpmScriptFile(nodeDir, "npx")
 
         def task = project.tasks.create('simple', NpxTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
 
         when:

--- a/src/test/groovy/com/github/gradle/node/task/AbstractTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/task/AbstractTaskTest.groovy
@@ -4,6 +4,7 @@ import com.github.gradle.AbstractProjectTest
 import com.github.gradle.node.NodeExtension
 import com.github.gradle.node.util.PlatformHelper
 import com.github.gradle.node.util.ProjectApiHelper
+import com.github.gradle.node.util.TestablePlatformHelper
 import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.process.ExecResult
@@ -16,12 +17,13 @@ abstract class AbstractTaskTest extends AbstractProjectTest {
     ExecSpec execSpec
     Properties props
     NodeExtension nodeExtension
-    PlatformHelper originalPlatformHelper
+    PlatformHelper testPlatformHelper
 
     def setup() {
         props = new Properties()
-        originalPlatformHelper = PlatformHelper.INSTANCE
-        PlatformHelper.INSTANCE = new PlatformHelper(props)
+        //default arch, can be changed by test
+        props.setProperty("os.arch", "x86_64")
+        testPlatformHelper = new TestablePlatformHelper(props)
 
         execSpec = Mock(ExecSpec)
         execResult = Mock(ExecResult)
@@ -30,8 +32,8 @@ abstract class AbstractTaskTest extends AbstractProjectTest {
         nodeExtension = NodeExtension.get(project)
     }
 
-    def cleanup() {
-        PlatformHelper.INSTANCE = originalPlatformHelper
+    protected mockPlatformHelper(BaseTask task) {
+        task.platformHelper = testPlatformHelper;
     }
 
     protected mockProjectApiHelperExec(Task task, String fieldName = "projectHelper") {

--- a/src/test/groovy/com/github/gradle/node/task/NodeTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/task/NodeTaskTest.groovy
@@ -19,6 +19,7 @@ class NodeTaskTest extends AbstractTaskTest {
         nodeExtension.download.set(false)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(['a', 'b'])
         task.options.set(['c', 'd'])
@@ -48,6 +49,7 @@ class NodeTaskTest extends AbstractTaskTest {
         nodeExtension.download.set(false)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.ignoreExitValue.set(true)
 
@@ -73,6 +75,7 @@ class NodeTaskTest extends AbstractTaskTest {
         nodeExtension.download.set(true)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         def script = new File(projectDir, 'script.js')
         task.script.set(script)
@@ -93,6 +96,7 @@ class NodeTaskTest extends AbstractTaskTest {
         nodeExtension.download.set(false)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         def script = new File(projectDir, 'script.js')
 
@@ -117,6 +121,7 @@ class NodeTaskTest extends AbstractTaskTest {
         nodeExtension.download.set(true)
 
         def task = project.tasks.create('simple', NodeTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         def script = new File(projectDir, 'script.js')
         task.script.set(script)

--- a/src/test/groovy/com/github/gradle/node/util/PlatformHelperTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/util/PlatformHelperTest.groovy
@@ -9,7 +9,7 @@ class PlatformHelperTest extends Specification {
 
     def setup() {
         this.props = new Properties()
-        PlatformHelper.INSTANCE = this.helper = new TestablePlatformHelper(this.props)
+        this.helper = new TestablePlatformHelper(this.props)
     }
 
     @Unroll

--- a/src/test/groovy/com/github/gradle/node/util/PlatformHelperTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/util/PlatformHelperTest.groovy
@@ -9,7 +9,7 @@ class PlatformHelperTest extends Specification {
 
     def setup() {
         this.props = new Properties()
-        PlatformHelper.INSTANCE = this.helper = new PlatformHelper(this.props)
+        PlatformHelper.INSTANCE = this.helper = new TestablePlatformHelper(this.props)
     }
 
     @Unroll

--- a/src/test/groovy/com/github/gradle/node/util/TestablePlatformHelper.groovy
+++ b/src/test/groovy/com/github/gradle/node/util/TestablePlatformHelper.groovy
@@ -1,0 +1,20 @@
+package com.github.gradle.node.util
+
+import org.jetbrains.annotations.NotNull
+
+//Extends PlatformHelper to override just how it access system props to make it more testable
+//without breaking configuration caching requirements
+//see https://github.com/node-gradle/gradle-node-plugin/issues/209
+class TestablePlatformHelper extends PlatformHelper {
+
+    private Properties props;
+
+    TestablePlatformHelper(Properties props) {
+        this.props = props
+    }
+
+    @Override
+    String getSystemProperty(@NotNull String name) {
+        return props.getProperty(name)
+    }
+}

--- a/src/test/groovy/com/github/gradle/node/variant/VariantComputerTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/variant/VariantComputerTest.groovy
@@ -1,7 +1,7 @@
 package com.github.gradle.node.variant
 
 import com.github.gradle.node.NodeExtension
-import com.github.gradle.node.util.PlatformHelper
+import com.github.gradle.node.util.TestablePlatformHelper
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Specification
 import spock.lang.Unroll
@@ -19,7 +19,6 @@ class VariantComputerTest extends Specification {
 
     def setup() {
         props = new Properties()
-        PlatformHelper.INSTANCE = new PlatformHelper(props)
     }
 
     @Unroll
@@ -29,6 +28,7 @@ class VariantComputerTest extends Specification {
 
         props.setProperty("os.name", "Windows 8")
         props.setProperty("os.arch", osArch)
+        def platformHelper = new TestablePlatformHelper(props)
 
         def nodeExtension = new NodeExtension(project)
         nodeExtension.download.set(true)
@@ -38,7 +38,7 @@ class VariantComputerTest extends Specification {
         def nodeDir = "node-v${version}-win-${osArch}".toString()
         def depName = "org.nodejs:node:${version}:win-${osArch}@zip".toString()
 
-        def variantComputer = new VariantComputer()
+        def variantComputer = new VariantComputer(platformHelper)
 
         when:
         def computedArchiveDependency = variantComputer.computeNodeArchiveDependency(nodeExtension)
@@ -72,6 +72,7 @@ class VariantComputerTest extends Specification {
         given:
         props.setProperty("os.name", osName)
         props.setProperty("os.arch", osArch)
+        def platformHelper = new TestablePlatformHelper(props)
 
         def project = ProjectBuilder.builder().build()
         def nodeExtension = new NodeExtension(project)
@@ -79,7 +80,7 @@ class VariantComputerTest extends Specification {
         nodeExtension.version.set('5.12.0')
         nodeExtension.workDir.set(project.layout.projectDirectory.dir(".gradle/node"))
 
-        def variantComputer = new VariantComputer()
+        def variantComputer = new VariantComputer(platformHelper)
 
         when:
         def computedArchiveDependency = variantComputer.computeNodeArchiveDependency(nodeExtension)
@@ -116,6 +117,8 @@ class VariantComputerTest extends Specification {
         given:
         props.setProperty("os.name", osName)
         props.setProperty("os.arch", osArch)
+        props.setProperty("uname", sysOsArch)
+        def platformHelper = new TestablePlatformHelper(props)
 
         def project = ProjectBuilder.builder().build()
         def nodeExtension = new NodeExtension(project)
@@ -123,9 +126,7 @@ class VariantComputerTest extends Specification {
         nodeExtension.version.set('5.12.0')
         nodeExtension.workDir.set(project.layout.projectDirectory.dir(".gradle/node"))
 
-        PlatformHelper platformHelperSpy = (PlatformHelper) Spy(PlatformHelper, constructorArgs: [props])
-        platformHelperSpy.osArch >> { sysOsArch }
-        def variantComputer = new VariantComputer(platformHelperSpy)
+        def variantComputer = new VariantComputer(platformHelper)
 
         when:
         def computedArchiveDependency = variantComputer.computeNodeArchiveDependency(nodeExtension)
@@ -157,13 +158,14 @@ class VariantComputerTest extends Specification {
         given:
         props.setProperty("os.name", "Windows 8")
         props.setProperty("os.arch", "x86")
+        def platformHelper = new TestablePlatformHelper(props)
         def project = ProjectBuilder.builder().build()
 
         def nodeExtension = new NodeExtension(project)
         nodeExtension.download.set(download)
         nodeExtension.npmVersion.set(npmVersion)
 
-        def variantComputer = new VariantComputer()
+        def variantComputer = new VariantComputer(platformHelper)
 
         when:
         def computedNodeDir = variantComputer.computeNodeDir(nodeExtension)
@@ -208,13 +210,14 @@ class VariantComputerTest extends Specification {
         given:
         props.setProperty("os.name", "Linux")
         props.setProperty("os.arch", "x86")
+        def platformHelper = new TestablePlatformHelper(props)
         def project = ProjectBuilder.builder().build()
 
         def nodeExtension = new NodeExtension(project)
         nodeExtension.download.set(download)
         nodeExtension.npmVersion.set(npmVersion)
 
-        def variantComputer = new VariantComputer()
+        def variantComputer = new VariantComputer(platformHelper)
 
         when:
         def computedNodeDir = variantComputer.computeNodeDir(nodeExtension)

--- a/src/test/groovy/com/github/gradle/node/yarn/task/YarnProxy_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/yarn/task/YarnProxy_integTest.groovy
@@ -5,7 +5,6 @@ import com.github.gradle.node.ProxyTestHelper
 import org.gradle.testkit.runner.TaskOutcome
 import org.mockserver.integration.ClientAndServer
 import org.mockserver.socket.PortFactory
-import spock.lang.Requires
 
 import static java.nio.charset.StandardCharsets.UTF_8
 import static org.mockserver.integration.ClientAndServer.startClientAndServer
@@ -13,7 +12,6 @@ import static org.mockserver.model.HttpRequest.request
 import static org.mockserver.model.SocketAddress.Scheme.HTTPS
 import static org.mockserver.verify.VerificationTimes.exactly
 
-@Requires({ System.getProperty("testProxyIntegrationTests").equals("true") })
 class YarnProxy_integTest extends AbstractIntegTest {
     private ClientAndServer proxyMockServer
     // We have to configure a second proxy otherwise Yarn does not want to use its own repository using HTTP,

--- a/src/test/groovy/com/github/gradle/node/yarn/task/YarnProxy_integTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/yarn/task/YarnProxy_integTest.groovy
@@ -10,7 +10,6 @@ import spock.lang.Requires
 import static java.nio.charset.StandardCharsets.UTF_8
 import static org.mockserver.integration.ClientAndServer.startClientAndServer
 import static org.mockserver.model.HttpRequest.request
-import static org.mockserver.model.SocketAddress.Scheme.HTTP
 import static org.mockserver.model.SocketAddress.Scheme.HTTPS
 import static org.mockserver.verify.VerificationTimes.exactly
 
@@ -47,10 +46,7 @@ class YarnProxy_integTest extends AbstractIntegTest {
                     request.removeHeader("host")
                     def targetHost = "registry.npmjs.org"
                     request.withHeader("host", targetHost)
-                    if (secure) {
-                        return request.withSocketAddress(targetHost, 443, HTTPS).withSecure(true)
-                    }
-                    return request.withSocketAddress(targetHost, 80, HTTP).withSecure(false)
+                    return request.withSocketAddress(targetHost, 443, HTTPS).withSecure(true)
                 }, { request, response ->
                     if (response.getBody().contentType == "application/vnd.npm.install-v1+json") {
                         // Let's rewrite download URLs in the JSON to make them target to the proxied registry
@@ -115,7 +111,7 @@ class YarnProxy_integTest extends AbstractIntegTest {
                     request.removeHeader("host")
                     def targetHost = "registry.npmjs.org"
                     request.withHeader("host", targetHost)
-                    return request.withSocketAddress(targetHost, 80, HTTP).withSecure(false)
+                    return request.withSocketAddress(targetHost, 443, HTTPS).withSecure(true)
                 }, { request, response ->
                     if (response.getBody().contentType == "application/vnd.npm.install-v1+json") {
                         // Let's rewrite download URLs in the JSON to make them target to the proxied registry

--- a/src/test/groovy/com/github/gradle/node/yarn/task/YarnTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/yarn/task/YarnTaskTest.groovy
@@ -35,6 +35,7 @@ class YarnTaskTest extends AbstractTaskTest {
         nodeExtension.download.set(true)
 
         def task = project.tasks.create('simple', YarnTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 
@@ -61,6 +62,7 @@ class YarnTaskTest extends AbstractTaskTest {
         GradleProxyHelper.setHttpsProxyPassword("password")
 
         def task = project.tasks.create('simple', YarnTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 
@@ -89,6 +91,7 @@ class YarnTaskTest extends AbstractTaskTest {
         nodeExtension.nodeProxySettings.set(ProxySettings.OFF)
 
         def task = project.tasks.create('simple', YarnTask)
+        mockPlatformHelper(task)
         mockProjectApiHelperExec(task)
         task.args.set(["run", "command"])
 


### PR DESCRIPTION
- Removed the `props` variable in `PlatformHelper` to avoid failures in 7.4
- Refactored use of PlatformHelper.INSTANCE just to tasks, the task then passes down its helper instance for Runner / VariantComputer use
- Added a new BaseTask class to hold common properties across all tasks, since PlatformHelper.INSTANCE isn't used anymore
- Tweaked some tests to use the Task sourced PlatformHelper, making execution deterministic and avoiding race conditions, no need for racey originalPlatformHelper anymore. Can probably run more tests in parallel now?
- Tweaked the proxy test server stuff to pass, non-secure would throw 404 for me, can likely back this out with more context. Also tweaked the request verification to be less fragile, was failing for me.
