### PR TITLE
adapts usage.md to contain current version

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ file (see [Installing](installation.md) for details):
 
 ```gradle
 plugins {
-  id "com.github.node-gradle.node" version "3.0.1"
+  id "com.github.node-gradle.node" version "3.2.1"
 }
 ```
 


### PR DESCRIPTION
This PR adapts the "usage.md" documentation to make use of the current version of this pulugin (3.2.1) instead of 3.0.1