### PR TITLE
adapts the default node version to the latest LTS version

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -204,7 +204,7 @@ node {
     
     // Version of node to download and install (only used if download is true)
     // It will be unpacked in the workDir
-    version = "12.18.3"
+    version = "16.14.0"
     
     // Version of npm to use
     // If specified, installs it in the npmWorkDir

--- a/src/test/resources/fixtures/kotlin/build.gradle.kts
+++ b/src/test/resources/fixtures/kotlin/build.gradle.kts
@@ -16,7 +16,7 @@ plugins {
 }
 
 node {
-    version.set("12.18.3")
+    version.set("16.14.0")
     npmVersion.set("")
     yarnVersion.set("")
     npmInstallCommand.set("install")


### PR DESCRIPTION
This pull request sets the default valio of "version" to the latest node LTS version (16.14.0)