### PR TITLE
Add ability do download node only once if needed

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -202,6 +202,12 @@ node {
     // Note that npm is bundled with Node.js
     download = false
     
+    // Whether to download and install a specific Node.js version only once or not
+    // If false, the plugin will act as configured, with no additional behaviour
+    // If true, the plugin will check if a specific Node.js version is installed (directory check)
+    // and if yes it will not download it again if *download* property s set to true 
+    downloadOnce = true
+    
     // Version of node to download and install (only used if download is true)
     // It will be unpacked in the workDir
     version = "16.14.0"

--- a/src/main/kotlin/com/github/gradle/node/NodeExtension.kt
+++ b/src/main/kotlin/com/github/gradle/node/NodeExtension.kt
@@ -86,6 +86,16 @@ open class NodeExtension(project: Project) {
     val download = project.objects.property<Boolean>().convention(false)
 
     /**
+     * Specify if you need to download and install a specific Node.js version
+     * or not if you already download it once
+     * If true, plugin will check if there is already one of Node.js
+     * of proper version downloaded and if [download] is true it will skip download task
+     * If false then it will have no effect and plugin will act as configured
+     * true by default
+     */
+    val downloadOnce = project.objects.property<Boolean>().convention(true)
+
+    /**
      * Whether the plugin automatically should add the proxy configuration to npm and yarn commands
      * according the proxy configuration defined for Gradle
      *


### PR DESCRIPTION
Hi. It would be great if we could control Node.js download process and not redownload it on every build.
In this PR we add such ability to this plugin, additional property *downloadOnce*, were added and if it is true and Node.js is already downloaded than it should not download it again.