### PR TITLE
Fix FAQ: Specify custom registry for setup

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -43,15 +43,13 @@ This can be done adding some arguments to the already defined `npmInstall`-task.
 npmInstall.args = ['--loglevel', 'silly']
 ```
 
-# How do I specify a registry for the NPM setup task?
+# How do I specify a registry for the NPM/yarn/Pnpm setup task?
 
-This can be done by adding to the arguments for the already defined `npmSetup` task.
+This can be done by adding to the arguments for the already defined `npmSetup`/`yarnSetup`/`pnpmSetup` tasks.
 
 ```gradle
-tasks.npmSetup {
-    doFirst {
-        args.addAll(['--registry', 'http://myregistry.npm.com'])
-    }
+tasks.<npm|yarn|pnpm>Setup {
+    args.addAll(['--registry', 'http://myregistry.npm.com'])
 }
 ```
 


### PR DESCRIPTION
Resolves #253 by fixing FAQ docs regarding specifying setup registries, to one that will work with other package managers.