### PR TITLE
Add missing `result` to NodeTask

### DIFF
--- a/src/main/kotlin/com/github/gradle/node/task/NodeTask.kt
+++ b/src/main/kotlin/com/github/gradle/node/task/NodeTask.kt
@@ -95,6 +95,6 @@ abstract class NodeTask : BaseTask() {
                 NodeExecConfiguration(command, environment.get(), workingDir.asFile.orNull,
                         ignoreExitValue.get(), execOverrides.orNull)
         val nodeExecRunner = NodeExecRunner()
-        nodeExecRunner.execute(projectHelper, extension, nodeExecConfiguration, variantComputer)
+        result = nodeExecRunner.execute(projectHelper, extension, nodeExecConfiguration, variantComputer)
     }
 }


### PR DESCRIPTION
With https://github.com/node-gradle/gradle-node-plugin/issues/237 all tasks except for NodeTask had `result` restored