### PR TITLE
[BUG FIX] Fix path resolution for executables

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
     id("com.cinnober.gradle.semver-git") version "3.0.0"
     id("org.jetbrains.dokka") version "1.7.10"
     id("org.gradle.test-retry") version "1.5.0"
+    `maven-publish`
 }
 
 group = "com.github.node-gradle"
@@ -58,6 +59,35 @@ dependencies {
     testImplementation("com.github.stefanbirkner:system-rules:1.19.0")
     testImplementation("org.mock-server:mockserver-netty:5.15.0")
 }
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+            groupId = "com.github.node-gradle"
+            artifactId = "gradle-node-plugin"
+            version = project.version.toString()
+            pom {
+                name.set("Gradle Node.js Plugin")
+                description.set("Gradle plugin for executing Node.js scripts. Supports npm, pnpm, Yarn, and Bun.")
+                url.set("https://github.com/node-gradle/gradle-node-plugin")
+                licenses {
+                    license {
+                        name.set("Apache License, Version 2.0")
+                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+                    }
+                }
+            }
+        }
+    }
+    repositories {
+        maven {
+            name = "localMaven"
+            url = uri("${buildDir}/maven-repo")
+        }
+    }
+}
+
 
 tasks.compileTestGroovy {
     // Should be

--- a/src/main/kotlin/com/github/gradle/node/NodeExtension.kt
+++ b/src/main/kotlin/com/github/gradle/node/NodeExtension.kt
@@ -5,6 +5,7 @@ import com.github.gradle.node.util.Platform
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.getByType
+import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 
 open class NodeExtension(project: Project) {
@@ -180,6 +181,9 @@ open class NodeExtension(project: Project) {
      * Operating system and architecture
      */
     val resolvedPlatform = project.objects.property<Platform>()
+
+
+    val environment = project.objects.mapProperty<String, String>().convention(System.getenv())
 
     init {
         distBaseUrl.set("https://nodejs.org/dist")

--- a/src/main/kotlin/com/github/gradle/node/exec/ExecRunner.kt
+++ b/src/main/kotlin/com/github/gradle/node/exec/ExecRunner.kt
@@ -36,6 +36,24 @@ fun computeWorkingDir(nodeProjectDir: DirectoryProperty, execConfiguration: Exec
 }
 
 /**
+ * Helper function to find the best matching executable in the system PATH.
+ *
+ * @param executableName The name of the executable to search for.
+ * @return The best matching executable path as a String.
+ */
+fun findBestExecutableMatch(executableName: String): String {
+    val pathVariable = System.getenv("PATH") ?: return executableName
+    val paths = pathVariable.split(File.pathSeparator)
+    for (path in paths) {
+        val executableFile = File(path, executableName)
+        if (executableFile.exists() && executableFile.canExecute()) {
+            return executableFile.absolutePath
+        }
+    }
+    return executableName  // Return the original executable if no match is found
+}
+
+/**
  * Basic execution runner that runs a given ExecConfiguration.
  *
  * Specific implementations likely use the same configuration but may assign
@@ -43,8 +61,9 @@ fun computeWorkingDir(nodeProjectDir: DirectoryProperty, execConfiguration: Exec
  */
 class ExecRunner {
     fun execute(projectHelper: ProjectApiHelper, extension: NodeExtension, execConfiguration: ExecConfiguration): ExecResult {
+        val executablePath = findBestExecutableMatch(execConfiguration.executable)
         return projectHelper.exec {
-            executable = execConfiguration.executable
+            executable = executablePath
             args = execConfiguration.args
             environment = computeEnvironment(execConfiguration)
             isIgnoreExitValue = execConfiguration.ignoreExitValue

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmInstallTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmInstallTaskTest.groovy
@@ -13,6 +13,7 @@ class NpmInstallTaskTest extends AbstractTaskTest {
     def "exec npm install task with configured proxy"() {
         given:
         nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Linux", "x86_64", {}))
+        nodeExtension.environment.set([:])
         GradleProxyHelper.setHttpsProxyHost("my-super-proxy.net")
         GradleProxyHelper.setHttpsProxyPort(11235)
 
@@ -32,6 +33,7 @@ class NpmInstallTaskTest extends AbstractTaskTest {
     def "exec npm install task with configured proxy but disabled"() {
         given:
         nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Linux", "x86_64", {}))
+        nodeExtension.environment.set([:])
         GradleProxyHelper.setHttpsProxyHost("my-super-proxy.net")
         GradleProxyHelper.setHttpsProxyPort(11235)
         nodeExtension.nodeProxySettings.set(ProxySettings.OFF)

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpmTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpmTaskTest.groovy
@@ -6,6 +6,8 @@ import com.github.gradle.node.npm.proxy.ProxySettings
 import com.github.gradle.node.task.AbstractTaskTest
 import com.github.gradle.node.util.PlatformHelperKt
 
+import java.nio.file.Files
+
 import static com.github.gradle.node.NodeExtension.DEFAULT_NODE_VERSION
 
 class NpmTaskTest extends AbstractTaskTest {
@@ -13,9 +15,83 @@ class NpmTaskTest extends AbstractTaskTest {
         GradleProxyHelper.resetProxy()
     }
 
+    /**
+     * Creates a temporary directory with a dummy executable file.
+     *
+     * @param fileName The name of the dummy executable (e.g., "npm").
+     * @param scriptContent (Optional) The content inside the executable. Defaults to a simple echo script.
+     * @return File object pointing to the dummy executable.
+     */
+    File createTempDummyExecutable(String fileName, String scriptContent = "#!/bin/bash\necho 'Dummy executable ran with args: \$@'") {
+        // Create a temporary directory
+        File tempDir = Files.createTempDirectory("dummy-bin").toFile()
+
+        // Create the dummy executable inside the temp directory
+        File executableFile = new File(tempDir, fileName)
+
+        // Write the script content
+        executableFile.text = scriptContent
+
+        // Set executable permissions
+        executableFile.setExecutable(true)
+
+        return executableFile
+    }
+
+    def "exec npm task with environment variable"() {
+        given:
+        def npmFile = createTempDummyExecutable("npm")
+
+        nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Linux", "x86_64", {}))
+        nodeExtension.environment.set(["PATH": npmFile.parent])
+
+        def task = project.tasks.create('simple', NpmTask)
+        mockProjectApiHelperExec(task)
+        task.args.set(['a', 'b'])
+        task.environment.set(['a': '1'])
+        task.ignoreExitValue.set(true)
+        task.workingDir.set(projectDir)
+
+        when:
+        project.evaluate()
+        task.exec()
+
+        then:
+        1 * execSpec.setIgnoreExitValue(true)
+        1 * execSpec.setEnvironment({ it['a'] == '1' && containsPath(it) })
+        1 * execSpec.setExecutable(npmFile.absolutePath)
+        1 * execSpec.setArgs(['a', 'b'])
+    }
+
+    def "exec npm task with environment variable (windows)"() {
+        given:
+        def npmFile = createTempDummyExecutable("npm.cmd")
+
+        nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Windows", "x86_64", {}))
+        nodeExtension.environment.set(["Path": npmFile.parent])
+
+        def task = project.tasks.create('simple', NpmTask)
+        mockProjectApiHelperExec(task)
+        task.args.set(['a', 'b'])
+        task.environment.set(['a': '1'])
+        task.ignoreExitValue.set(true)
+        task.workingDir.set(projectDir)
+
+        when:
+        project.evaluate()
+        task.exec()
+
+        then:
+        1 * execSpec.setIgnoreExitValue(true)
+        1 * execSpec.setEnvironment({ it['a'] == '1' && containsPath(it) })
+        1 * execSpec.setExecutable(npmFile.absolutePath)
+        1 * execSpec.setArgs(['a', 'b'])
+    }
+
     def "exec npm task"() {
         given:
         nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Linux", "x86_64", {}))
+        nodeExtension.environment.set([:])
 
         def task = project.tasks.create('simple', NpmTask)
         mockProjectApiHelperExec(task)
@@ -55,6 +131,39 @@ class NpmTaskTest extends AbstractTaskTest {
         1 * execSpec.setEnvironment({ it['a'] == '1' && containsPath(it) })
         1 * execSpec.setExecutable('npm.cmd')
         1 * execSpec.setArgs(['a', 'b'])
+    }
+
+    def "exec npm task with path respects download"() {
+        given:
+        def npmFile = createTempDummyExecutable("npm")
+
+        nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Linux", "x86_64", {}))
+        nodeExtension.environment.set(["PATH": npmFile.parent])
+        nodeExtension.download.set(true)
+
+        def nodeDir = projectDir.toPath().resolve(".gradle").resolve("nodejs")
+                .resolve("node-v${DEFAULT_NODE_VERSION}-linux-x64")
+
+        def task = project.tasks.create('simple', NpmTask)
+        mockProjectApiHelperExec(task)
+        task.args.set(["run", "command"])
+
+        when:
+        project.evaluate()
+        task.exec()
+
+        then:
+        1 * execSpec.setIgnoreExitValue(false)
+        1 * execSpec.setExecutable({ executable ->
+            def expectedNodePath = nodeDir.resolve("bin").resolve("node")
+            return fixAbsolutePath(executable) == expectedNodePath.toAbsolutePath().toString()
+        })
+        1 * execSpec.setArgs({ args ->
+            def command = nodeDir
+                    .resolve("lib").resolve("node_modules").resolve("npm").resolve("bin")
+                    .resolve("npm-cli.js").toAbsolutePath().toString()
+            return fixAbsolutePaths(args) == [command, "run", "command"]
+        })
     }
 
     def "exec npm task (download)"() {
@@ -121,6 +230,8 @@ class NpmTaskTest extends AbstractTaskTest {
     def "exec npm task with configured proxy"() {
         given:
         nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Linux", "x86_64", {}))
+        nodeExtension.environment.set([:])
+
         GradleProxyHelper.setHttpsProxyHost("my-super-proxy.net")
         GradleProxyHelper.setHttpsProxyPort(11235)
 
@@ -141,6 +252,8 @@ class NpmTaskTest extends AbstractTaskTest {
     def "exec npm task with configured proxy but disabled"() {
         given:
         nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Linux", "x86_64", {}))
+        nodeExtension.environment.set([:])
+
         GradleProxyHelper.setHttpsProxyHost("my-super-proxy.net")
         GradleProxyHelper.setHttpsProxyPort(11235)
         nodeExtension.nodeProxySettings.set(ProxySettings.OFF)

--- a/src/test/groovy/com/github/gradle/node/npm/task/NpxTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/npm/task/NpxTaskTest.groovy
@@ -10,6 +10,7 @@ class NpxTaskTest extends AbstractTaskTest {
     def "exec npx task"() {
         given:
         nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Linux", "x86_64", {}))
+        nodeExtension.environment.set([:])
 
         def task = project.tasks.create('simple', NpxTask)
         mockProjectApiHelperExec(task)

--- a/src/test/groovy/com/github/gradle/node/task/NodeTaskTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/task/NodeTaskTest.groovy
@@ -18,6 +18,7 @@ class NodeTaskTest extends AbstractTaskTest {
     def "exec node task"() {
         given:
         nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Linux", "x86_64", {}))
+        nodeExtension.environment.set([:])
         nodeExtension.download.set(false)
 
         def task = project.tasks.create('simple', NodeTask)
@@ -93,6 +94,7 @@ class NodeTaskTest extends AbstractTaskTest {
         given:
         nodeExtension.resolvedPlatform.set(PlatformHelperKt.parsePlatform("Windows", "x86_64", {}))
         nodeExtension.download.set(false)
+        nodeExtension.environment.set([:])
 
         def task = project.tasks.create('simple', NodeTask)
         mockProjectApiHelperExec(task)

--- a/src/test/groovy/com/github/gradle/node/variant/VariantComputerTest.groovy
+++ b/src/test/groovy/com/github/gradle/node/variant/VariantComputerTest.groovy
@@ -157,6 +157,7 @@ class VariantComputerTest extends Specification {
         nodeExtension.resolvedPlatform.set(platform)
         nodeExtension.download.set(download)
         nodeExtension.npmVersion.set(npmVersion)
+        nodeExtension.environment.set([:])
 
         def variantComputer = new VariantComputer()
 
@@ -208,6 +209,7 @@ class VariantComputerTest extends Specification {
         nodeExtension.resolvedPlatform.set(platform)
         nodeExtension.download.set(download)
         nodeExtension.npmVersion.set(npmVersion)
+        nodeExtension.environment.set([:])
 
         def variantComputer = new VariantComputer()
 


### PR DESCRIPTION
There’s an issue with mac silicion+intellij, whereby gradle process executor is not respecting path environment variables.

This gets around that by using a fix for the plugin whereby we attempt to resolve the path manually.

https://github.com/node-gradle/gradle-node-plugin/issues/152

https://youtrack.jetbrains.com/issue/IDEA-334183

We hit this constantly with our development team and this fix resolved it for us.