### PR TITLE
Only use architecture of first CPU in Windows

### DIFF
--- a/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
@@ -96,7 +96,7 @@ fun main(args: Array<String>) {
     val osType = parseOsType(osName)
     val uname = {
         val args = if (osType == OsType.WINDOWS) {
-            listOf("powershell", "-NoProfile", "-Command", "(Get-WmiObject Win32_Processor).Architecture")
+            listOf("powershell", "-NoProfile", "-Command", "(Get-WmiObject Win32_Processor)[0].Architecture")
         } else {
             listOf("uname", "-m")
         }

--- a/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
+++ b/src/main/kotlin/com/github/gradle/node/util/PlatformHelper.kt
@@ -96,7 +96,7 @@ fun main(args: Array<String>) {
     val osType = parseOsType(osName)
     val uname = {
         val args = if (osType == OsType.WINDOWS) {
-            listOf("powershell", "-NoProfile", "-Command", "(Get-WmiObject Win32_Processor)[0].Architecture")
+            listOf("powershell", "-NoProfile", "-Command", "(Get-WmiObject Win32_Processor | Select-Object -First 1).Architecture")
         } else {
             listOf("uname", "-m")
         }


### PR DESCRIPTION
Some VMs expose multiple cores as multiple CPUs, which breaks the current check for architecture type. This isolates the first CPU, fixing the incompatibility.